### PR TITLE
Add JSON download for scan results

### DIFF
--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState, useEffect, useRef } from 'react';
-import { ExternalLink, Printer, Shield, AlertTriangle, Globe, Server, Lock, User, Clock, Zap, Phone, MessageCircle, Map, GitBranch, Code, Brain, ChevronDown, ChevronUp, SendHorizontal, Mail, Copy, Eye, ShieldAlert } from 'lucide-react';
+import { ExternalLink, Printer, Download, Shield, AlertTriangle, Globe, Server, Lock, User, Clock, Zap, Phone, MessageCircle, Map, GitBranch, Code, Brain, ChevronDown, ChevronUp, SendHorizontal, Mail, Copy, Eye, ShieldAlert } from 'lucide-react';
 import type { ScanResults, ScanMeta, OpsecFinding } from '@/lib/types';
 import { fetchReportBlob, generateAiSummary, sendAiChat, getMapData, getGraphData } from '@/lib/api';
 import { useTranslations } from '@/lib/i18n';
@@ -27,6 +27,10 @@ let leafletLoader: Promise<any> | null = null;
 
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string));
+}
+
+function filenameSegment(value: string): string {
+  return value.trim().replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'scan';
 }
 
 function loadLeaflet(): Promise<any> {
@@ -384,6 +388,22 @@ export function ScanResults({ scan }: Props) {
     }
   };
 
+  const downloadJson = () => {
+    try {
+      const blob = new Blob([JSON.stringify(scan.results, null, 2)], { type: 'application/json' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `prism-${filenameSegment(scan.target)}-${filenameSegment(scan.id)}.json`;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      setTimeout(() => URL.revokeObjectURL(url), 0);
+    } catch (e: unknown) {
+      showToast(e instanceof Error ? e.message : 'JSON download failed');
+    }
+  };
+
   const visibleTabs = TABS.filter(t => {
     if (t.id === 'whois') return r.whois && !r.whois.error;
     if (t.id === 'dns') return r.dns?.records && Object.keys(r.dns.records).length > 0;
@@ -415,7 +435,7 @@ export function ScanResults({ scan }: Props) {
             )}
           </div>
         </div>
-        <div className="flex gap-2">
+        <div className="flex flex-wrap gap-2 sm:justify-end">
           <button type="button" onClick={() => openReport('html')} disabled={reportLoading !== null}
             className="btn-ghost text-[11px] h-8 px-3">
             {reportLoading === 'html' ? '…' : <ExternalLink size={11} />} {i18n('results.htmlReport')}
@@ -423,6 +443,10 @@ export function ScanResults({ scan }: Props) {
           <button type="button" onClick={() => openReport('pdf')} disabled={reportLoading !== null}
             className="btn-ghost text-[11px] h-8 px-3">
             {reportLoading === 'pdf' ? '…' : <Printer size={11} />} {i18n('results.pdfReport')}
+          </button>
+          <button type="button" onClick={downloadJson}
+            className="btn-ghost text-[11px] h-8 px-3">
+            <Download size={11} /> {i18n('results.jsonReport')}
           </button>
         </div>
       </div>

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -55,6 +55,7 @@
   "results": {
     "htmlReport": "HTML-Bericht",
     "pdfReport": "PDF-Bericht",
+    "jsonReport": "JSON herunterladen",
     "tabs": {
       "findings": "Befunde",
       "whois": "WHOIS",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -55,6 +55,7 @@
   "results": {
     "htmlReport": "HTML Report",
     "pdfReport": "PDF Report",
+    "jsonReport": "Download JSON",
     "tabs": {
       "findings": "Findings",
       "whois": "WHOIS",

--- a/frontend/src/messages/ru.json
+++ b/frontend/src/messages/ru.json
@@ -55,6 +55,7 @@
   "results": {
     "htmlReport": "HTML отчёт",
     "pdfReport": "PDF отчёт",
+    "jsonReport": "Скачать JSON",
     "tabs": {
       "findings": "Находки",
       "whois": "WHOIS",


### PR DESCRIPTION
## Summary

- Add a `Download JSON` action next to the existing HTML/PDF report buttons.
- Serialize `scan.results` to a JSON Blob and download it as `prism-{target}-{scan_id}.json` with filename-safe target/id segments.
- Add localized button labels and allow the report action row to wrap on narrow screens.

Closes #30

## Testing

- `npm ci`
- `npm run build`
- `npx tsc --noEmit`
- `git diff --check`
- `npm run lint` was attempted, but the repo prompts to configure ESLint because no ESLint config is present, so I did not add unrelated config changes.