### PR TITLE
Add Docker health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,7 @@ RUN mkdir -p results
 
 EXPOSE 8080
 
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+  CMD curl -f http://localhost:8080/ || exit 1
+
 CMD ["python", "-m", "uvicorn", "web.app:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary

Added a Docker HEALTHCHECK instruction so container orchestrators can detect unhealthy backend containers automatically.

## Changes

* Added HEALTHCHECK to Dockerfile
* Uses curl to verify the backend responds on port 8080
* Marks container unhealthy if the backend stops responding

Closes #32

## Testing

* Verified Dockerfile syntax
* Health check targets `http://localhost:8080/`
