### PR TITLE
fix: add missing idle.demo translations to all language JSONs

### DIFF
--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -75,6 +75,12 @@
       "crypto":   { "label": "Krypto-Adresse",    "desc": "Bitcoin und Ethereum" },
       "qr":       { "label": "QR-Decoder",        "desc": "Decodieren & analysieren" },
       "mac":      { "label": "MAC Lookup",        "desc": "Hersteller-Suche" }
+    },
+    "demo": {
+      "line1": "Dies ist eine öffentliche Demo mit begrenzten API-Kontingenten. Manche Module (Shodan, VirusTotal) können ratenbegrenzt sein.",
+      "line2Prefix": "Für vollen Zugriff",
+      "selfHost": "PRISM selbst hosten",
+      "line2Suffix": "mit eigenen API-Schlüsseln."
     }
   },
   "toolPanels": {

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -75,6 +75,12 @@
       "crypto":   { "label": "Crypto Address", "desc": "Bitcoin & Ethereum" },
       "qr":       { "label": "QR Decode",       "desc": "Decode & analyze" },
       "mac":      { "label": "MAC Lookup",      "desc": "Vendor lookup" }
+    },
+    "demo": {
+      "line1": "This is a public demo with limited API quotas. Some modules (Shodan, VirusTotal) may be rate-limited.",
+      "line2Prefix": "For full access,",
+      "selfHost": "self-host PRISM",
+      "line2Suffix": "with your own API keys."
     }
   },
   "toolPanels": {

--- a/frontend/src/messages/ru.json
+++ b/frontend/src/messages/ru.json
@@ -75,6 +75,12 @@
       "crypto":   { "label": "Крипто-адрес",     "desc": "Bitcoin и Ethereum" },
       "qr":       { "label": "Декодер QR",         "desc": "Декодирование и анализ" },
       "mac":      { "label": "MAC Lookup",        "desc": "Поиск производителя" }
+    },
+    "demo": {
+      "line1": "Это публичное демо с ограниченными квотами API. Некоторые модули (Shodan, VirusTotal) могут быть ограничены частотой запросов.",
+      "line2Prefix": "Для полного доступа",
+      "selfHost": "разверни PRISM сам",
+      "line2Suffix": "со своими API-ключами."
     }
   },
   "toolPanels": {


### PR DESCRIPTION
- IdleView was calling t('idle.demo.line1/suffix/etc') but these keys were missing
- Added demo section with line1, line2Prefix, selfHost, line2Suffix to en/ru/de
- Build passes
<img width="669" height="129" alt="Screenshot 2026-05-31 at 19 14 42" src="https://github.com/user-attachments/assets/307fdab5-a0ba-4e25-91d5-0920d0c200b3" />
<img width="747" height="147" alt="Screenshot 2026-05-31 at 19 14 46" src="https://github.com/user-attachments/assets/f39fb603-e56d-4723-8fb4-cce756b00ccc" />
<img width="686" height="129" alt="Screenshot 2026-05-31 at 19 14 35" src="https://github.com/user-attachments/assets/8799beeb-ce7a-4e39-b60f-f27b88d1a282" />
