### PR TITLE
feature : add localized API documentation link to topbar

### DIFF
--- a/frontend/src/components/Topbar.tsx
+++ b/frontend/src/components/Topbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { Loader2, CheckCircle, XCircle, Github, Terminal, Sun, Moon, Menu, Languages } from 'lucide-react';
+import { Loader2, CheckCircle, XCircle, Github, Terminal, Sun, Moon, Menu, Languages, Book } from 'lucide-react';
 import { useTheme } from '@/lib/useTheme';
 import { useTranslations, SUPPORTED_LOCALES } from '@/lib/i18n';
 import { Logo } from './Logo';
@@ -106,6 +106,16 @@ export function Topbar({ status, onHome, onMenuToggle }: Props) {
         >
           {mounted ? (theme === 'dark' ? <Sun size={15} /> : <Moon size={15} />) : <Sun size={15} />}
         </button>
+        <a
+          href="https://github.com/NovaCode37/Prism-platform#api"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-text-3 hover:text-text-1 transition-colors"
+          title="API Documentation"
+          aria-label="API Documentation"
+        >
+          <Book size={15} />
+        </a>
         <a
           href="https://github.com/NovaCode37/Prism-platform"
           target="_blank"

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -5,7 +5,8 @@
     "complete": "Fertig",
     "failed": "Fehlgeschlagen",
     "toggleTheme": "Design wechseln",
-    "github": "GitHub"
+    "github": "GitHub",
+    "apiDocs":"API-Dokumentation"
   },
   "sidebar": {
     "target": "Ziel",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -5,7 +5,8 @@
     "complete": "Complete",
     "failed": "Failed",
     "toggleTheme": "Toggle theme",
-    "github": "GitHub"
+    "github": "GitHub",
+    "apiDocs": "API Documentation"
   },
   "sidebar": {
     "target": "Target",

--- a/frontend/src/messages/ru.json
+++ b/frontend/src/messages/ru.json
@@ -5,7 +5,8 @@
     "complete": "Готово",
     "failed": "Ошибка",
     "toggleTheme": "Сменить тему",
-    "github": "GitHub"
+    "github": "GitHub",
+    "apiDocs": "Документация API"
   },
   "sidebar": {
     "target": "Цель",


### PR DESCRIPTION
This PR adds a dedicated "API Docs" link to the Topbar, as requested in issue #57 .

Changes:

Added Book icon link pointing to the url "https://github.com/NovaCode37/Prism-platform#api"

Added apiDocs key to en.json, ru.json, and de.json for localization.

Ensured the link opens in a new tab for better user experience.

Closes #57 
<img width="475" height="187" alt="image" src="https://github.com/user-attachments/assets/75a20f75-331d-4960-9e17-3d341056ed46" />
