### PR TITLE
Add .gitattributes to enforce LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto eol=lf
+*.png binary
+*.jpg binary
+*.gif binary
+*.ttf binary


### PR DESCRIPTION
## Description
Creates a .gitattributes file to normalize line endings across all platforms.

## Changes
- Added .gitattributes in repository root
- Sets text=auto eol=lf for consistent LF line endings
- Marks image/font files as binary to prevent line ending conversion

Fixes issue #90