### PR TITLE
Add clear scan history feature

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,7 +2,7 @@
 import { useState, useEffect, useRef } from 'react';
 import { Play, Loader2, ChevronDown, ChevronUp, Lightbulb, RotateCcw, Trash2, History, GitCompare } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
-import { listScans, type ScanListItem } from '@/lib/api';
+import { listScans, clearScans, type ScanListItem } from '@/lib/api';
 import type { ScanType } from '@/lib/types';
 
 const TYPE_COLOR: Record<ScanType, string> = {
@@ -88,6 +88,22 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isOpen, onCl
     }
     setHistoryLoading(false);
   };
+
+  const handleClearHistory = async () => {
+  const confirmed = window.confirm(
+    'Are you sure you want to clear your scan history?'
+  );
+
+  if (!confirmed) return;
+
+  try {
+    await clearScans();
+    await fetchHistory();
+  } catch (err) {
+    console.error(err);
+    alert('Failed to clear scan history');
+  }
+};
 
   const toggleHistory = () => {
     const next = !showHistory;
@@ -258,6 +274,10 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isOpen, onCl
                 <GitCompare size={10} /> {t('sidebar.compareSelected')}
               </button>
             )}
+
+
+
+
             <div className="flex items-center gap-1 mb-1.5">
               <button
                 onClick={() => { setCompareMode(v => !v); setCompareSelection([]); }}
@@ -265,12 +285,28 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isOpen, onCl
                   compareMode ? 'bg-purple/20 text-purple border border-purple/30' : 'bg-surface-3 text-text-3 border border-border-1 hover:text-text-2'
                 }`}
               >
+                
                 <span className="flex items-center gap-1"><GitCompare size={8} /> {t('sidebar.compare')}</span>
               </button>
+
+  <button
+    onClick={handleClearHistory}
+    className="text-text-3 hover:text-red transition-colors"
+  >
+    <Trash2 size={10} />
+  </button>
+
+
               <button onClick={fetchHistory} className="text-text-3 hover:text-text-2 transition-colors ml-auto">
                 <RotateCcw size={10} className={historyLoading ? 'spin' : ''} />
               </button>
             </div>
+
+
+
+
+
+
             {historyLoading ? (
               <div className="flex justify-center py-2"><Loader2 size={14} className="spin text-text-3" /></div>
             ) : history.length === 0 ? (

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -112,6 +112,20 @@ export async function listScans(): Promise<ScanListItem[]> {
   return r.json();
 }
 
+export async function clearScans(): Promise<{ deleted: number }> {
+  const r = await fetch(`${API}/api/scans`, {
+    method: 'DELETE',
+    headers: authHeaders(),
+  });
+
+  if (!r.ok) {
+    throw new Error('Failed to clear scan history');
+  }
+
+  return r.json();
+}
+
+
 export async function fetchReportBlob(scanId: string, format: 'html' | 'pdf', lang?: string): Promise<Blob> {
   const suffix = format === 'pdf' ? '/pdf' : '';
   const q = lang ? `?lang=${encodeURIComponent(lang)}` : '';

--- a/web/app.py
+++ b/web/app.py
@@ -1099,6 +1099,45 @@ async def list_scans(request: Request):
         for s in all_scans
     ]
 
+@app.delete("/api/scans", dependencies=[Depends(require_api_key)])
+@limiter.limit("10/minute")
+async def clear_scans(request: Request):
+    principal = get_principal(request)
+    deleted = 0
+
+    try:
+        for fname in os.listdir(_SCANS_DIR):
+            if not fname.endswith(".json"):
+                continue
+
+            path = os.path.join(_SCANS_DIR, fname)
+
+            try:
+                with open(path, "r", encoding="utf-8") as f:
+                    scan = json.load(f)
+            except Exception:
+                continue
+
+            if (scan.get("owner") or ANONYMOUS_PRINCIPAL) != principal:
+                continue
+
+            try:
+                os.remove(path)
+                deleted += 1
+            except Exception:
+                pass
+
+        return {"deleted": deleted}
+
+    except Exception as e:
+        return JSONResponse(
+            {"error": str(e)},
+            status_code=500
+        )
+
+
+
+
 @app.websocket("/ws/{scan_id}")
 async def websocket_endpoint(websocket: WebSocket, scan_id: str):
     try:


### PR DESCRIPTION
Added a new "Clear Scan History" feature that allows users to remove all previously stored scan history with a single action.

## Changes

- Added Clear Scan History functionality
- Added UI action/button for clearing scan history
- Implemented logic to remove stored scan records
- Updated related components and API handling where required
- Improved user experience by allowing users to manage scan history easily


