### PR TITLE
feat: add JWT decoder standalone tool

### DIFF
--- a/frontend/src/components/tools/ToolPanels.tsx
+++ b/frontend/src/components/tools/ToolPanels.tsx
@@ -134,7 +134,6 @@ function DropZone({ accept, file, onChange, hint }: { accept: string; file: File
     </label>
   );
 }
-
 function QrPanel() {
   const { t } = useTranslations();
   const [file, setFile] = useState<File | null>(null);
@@ -312,7 +311,6 @@ function HashPanel() {
 
     if (!trimmed) return;
 
-    // Check if it's valid hex
     if (!/^[a-f0-9]*$/.test(trimmed)) {
       setError(t('toolPanels.hash.invalidHex'));
       return;
@@ -356,7 +354,6 @@ function HashPanel() {
     </div>
   );
 }
-
 function EncoderPanel() {
   const { t } = useTranslations();
   const [input, setInput] = useState('');
@@ -421,6 +418,90 @@ function EncoderPanel() {
   );
 }
 
+function base64UrlDecode(str: string): string {
+  const padded = str.replace(/-/g, '+').replace(/_/g, '/');
+  const pad = padded.length % 4;
+  const withPad = pad ? padded + '='.repeat(4 - pad) : padded;
+  return decodeURIComponent(escape(atob(withPad)));
+}
+
+function formatTimestamp(value: unknown): string | null {
+  if (typeof value !== 'number') return null;
+  const date = new Date(value * 1000);
+  if (isNaN(date.getTime())) return null;
+  return date.toLocaleString();
+}
+
+function JwtPanel() {
+  const { t } = useTranslations();
+  const [token, setToken] = useState('');
+  const [result, setResult] = useState<import('@/lib/types').JwtResult | null>(null);
+
+  const run = () => {
+    const trimmed = token.trim();
+    if (!trimmed) return;
+    const parts = trimmed.split('.');
+    if (parts.length !== 3) {
+      setResult({ error: t('toolPanels.jwt.invalid') });
+      return;
+    }
+    try {
+      const header = JSON.parse(base64UrlDecode(parts[0]));
+      const payload = JSON.parse(base64UrlDecode(parts[1]));
+      setResult({
+        header,
+        payload,
+        iat: formatTimestamp(payload.iat),
+        exp: formatTimestamp(payload.exp),
+        nbf: formatTimestamp(payload.nbf),
+      });
+    } catch {
+      setResult({ error: t('toolPanels.jwt.invalid') });
+    }
+  };
+
+  const isExpired = result?.payload && typeof result.payload.exp === 'number' && result.payload.exp * 1000 < Date.now();
+
+  return (
+    <div>
+      <Card title={t('toolPanels.jwt.title')}>
+        <textarea
+          value={token}
+          onChange={e => setToken(e.target.value)}
+          placeholder={t('toolPanels.jwt.placeholder')}
+          className="input-field font-mono text-[11px] resize-y leading-relaxed w-full mb-3"
+          rows={4}
+        />
+        <RunBtn loading={false} label={t('toolPanels.jwt.decode')} onClick={run} disabled={!token.trim()} />
+      </Card>
+      {result && (
+        result.error ? (
+          <ErrorCard label={t('toolPanels.error')} message={result.error} />
+        ) : (
+          <div>
+            {isExpired && (
+              <div className="text-[11px] text-red mb-2 px-1">{t('toolPanels.jwt.expired')}</div>
+            )}
+            <Card title={t('toolPanels.jwt.header')}>
+              <textarea readOnly value={JSON.stringify(result.header, null, 2)} rows={4}
+                className="input-field font-mono text-[11px] resize-y leading-relaxed w-full" />
+            </Card>
+            <Card title={t('toolPanels.jwt.payload')}>
+              <textarea readOnly value={JSON.stringify(result.payload, null, 2)} rows={8}
+                className="input-field font-mono text-[11px] resize-y leading-relaxed w-full" />
+            </Card>
+            <Card>
+              <Row label={t('toolPanels.jwt.issuedAt')} value={result.iat ?? undefined} />
+              <Row label={t('toolPanels.jwt.expiresAt')} value={result.exp ?? undefined} />
+              <Row label={t('toolPanels.jwt.notBefore')} value={result.nbf ?? undefined} />
+            </Card>
+            <div className="text-[10px] text-text-3 px-1">{t('toolPanels.jwt.noSignatureWarning')}</div>
+          </div>
+        )
+      )}
+    </div>
+  );
+}
 function HeadersPanel() {
   const { t } = useTranslations();
   const [text, setText] = useState('');
@@ -491,7 +572,6 @@ function HeadersPanel() {
 function SubnetPanel() {
   const { t } = useTranslations();
 
-  // ── pure-JS subnet math (no external deps) ──────────────────────────────
   function ipToInt(ip: string): number {
     return ip.split('.').reduce((acc, oct) => (acc << 8) + parseInt(oct, 10), 0) >>> 0;
   }
@@ -577,7 +657,6 @@ function SubnetPanel() {
   return (
     <div>
       <Card>
-        {/* Mode toggle */}
         <div className="flex gap-2 mb-3">
           {(['cidr', 'mask'] as const).map(m => (
             <button key={m} onClick={() => { setPrefixMode(m); setPrefix(m === 'cidr' ? '24' : '255.255.255.0'); setErrors({}); }}
@@ -587,7 +666,6 @@ function SubnetPanel() {
           ))}
         </div>
 
-        {/* Inputs */}
         <div className="flex gap-2 flex-wrap mb-2">
           <div className="flex flex-col gap-1 flex-1 min-w-[140px]">
             <input className="input-field" value={ip} onChange={e => { setIp(e.target.value); setErrors(p => ({ ...p, ip: undefined })); }}
@@ -607,7 +685,6 @@ function SubnetPanel() {
           <RunBtn loading={false} label="Calculate" onClick={run} />
         </div>
 
-        {/* CIDR slider */}
         {prefixMode === 'cidr' && (
           <div className="mt-3">
             <input type="range" min="0" max="32"
@@ -643,6 +720,7 @@ const TOOL_TITLES: Record<string, string> = {
   crypto: 'Crypto Address Lookup', qr: 'QR Code Decoder',
   metadata: 'File Metadata & GEOINT', headers: 'Email Header Analyzer', mac: 'MAC Lookup',
   subnet: 'IP / Subnet Calculator', hash: 'Hash Identifier', encoder: 'Base64 & URL Encoder',
+  jwt: 'JWT Decoder',
 };
 
 interface Props {
@@ -673,6 +751,7 @@ export function ToolPanels({ mode, onBack }: Props) {
       {activePanel === 'mac' && <MacPanel />}
       {activePanel === 'hash' && <HashPanel />}
       {activePanel === 'encoder' && <EncoderPanel />}
+      {activePanel === 'jwt' && <JwtPanel />}
     </div>
   );
 }

--- a/frontend/src/components/views/IdleView.tsx
+++ b/frontend/src/components/views/IdleView.tsx
@@ -1,11 +1,11 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { FileText, Mail, Bitcoin, QrCode, ChevronRight, Globe, User, Phone, Shield, Database, Zap, Eye, Activity, Network, Hash, Binary } from 'lucide-react';
+import { FileText, Mail, Bitcoin, QrCode, ChevronRight, Globe, User, Phone, Shield, Database, Zap, Eye, Activity, Network, Hash, Binary, KeyRound } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
 import { Logo } from '../Logo';
 import type { ToolMode } from '@/lib/types';
 
-const TOOL_IDS = ['metadata', 'headers', 'crypto', 'qr', 'mac', 'subnet', 'hash', 'encoder'] as const;
+const TOOL_IDS = ['metadata', 'headers', 'crypto', 'qr', 'mac', 'subnet', 'hash', 'encoder', 'jwt'] as const;
 type ToolId = typeof TOOL_IDS[number];
 
 const ICONS: Record<ToolId, React.ElementType> = {
@@ -17,6 +17,7 @@ const ICONS: Record<ToolId, React.ElementType> = {
   mac: Network,
   hash: Hash,
   encoder: Binary,
+  jwt: KeyRound,
 };
 
 const CAPS_KEYS = ['domain', 'email', 'phone', 'username'] as const;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,6 +1,6 @@
 export type ScanType = 'domain' | 'ip' | 'email' | 'phone' | 'username';
 export type ScanStatus = 'idle' | 'running' | 'completed' | 'failed';
-export type ToolMode = 'metadata' | 'headers' | 'crypto' | 'qr' | 'mac' | 'subnet' | 'hash' | 'encoder' | null;
+export type ToolMode = 'metadata' | 'headers' | 'crypto' | 'qr' | 'mac' | 'subnet' | 'hash' | 'encoder' | 'jwt' | null;
 
 /** Standard per-module result status (mirrors modules/module_status.py). */
 export type ModuleStatus = 'ok' | 'skipped' | 'rate_limited' | 'error';
@@ -326,5 +326,14 @@ export interface MetaResult {
 export interface MacResult {
   mac?: string;
   vendor?: string | null;
+  error?: string;
+}
+
+export interface JwtResult {
+  header?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+  exp?: string | null;
+  iat?: string | null;
+  nbf?: string | null;
   error?: string;
 }

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -85,7 +85,8 @@
       "mac":      { "label": "MAC Lookup",      "desc": "Vendor lookup" },
       "subnet":   { "label": "IP / Subnet",     "desc": "Network ranges & CIDR" },
       "hash":     { "label": "Hash Identifier", "desc": "Identify hash types" },
-      "encoder":  { "label": "Base64 / URL", "desc": "Encode & decode" }
+      "encoder":  { "label": "Base64 / URL", "desc": "Encode & decode" },
+      "jwt": { "label": "JWT Decoder", "desc": "Decode JWT tokens" }
     },
     "demo": {
       "line1": "This is a public demo with limited API quotas. Some modules (Shodan, VirusTotal) may be rate-limited.",
@@ -187,6 +188,19 @@
       "decode": "Decode",
       "output": "Output",
       "invalid": "Invalid input for the selected mode."
+    },
+    "jwt": {
+      "title": "JWT Decoder",
+      "placeholder": "Paste a JWT token(eyj...)...",
+      "decode": "Decode",
+      "header": "Header",
+      "playload": "Payload",
+      "issuedAt": "Issued At",
+      "expiresAt": "Expires At",
+      "notBefore": "Not before",
+      "expired": "⚠ Token expired",
+      "noSignatureWarning": "Signature is not verified - this tool only decodes.",
+      "invalid": "Invalid JWT format. Expected tthree dot-seperated parts: header.playload.signature"
     }
   },
   "progress": {


### PR DESCRIPTION
## Summary
Adds a standalone JWT decoder tool that splits a token by `.`, base64url-decodes the header and payload, formats the JSON, and shows `exp`/`iat`/`nbf` as readable dates. No signature verification — decode only, clearly labeled.

Closes #126

## Changes
- Added `JwtPanel` to `ToolPanels.tsx` with header/payload decoding, formatted timestamps, and an expired-token warning
- Registered the new tool in `IdleView.tsx` (icon, label, description) and `types.ts` (`ToolMode`, `JwtResult`)
- Added English translations under `toolPanels.jwt` and `idle.tools.jwt`
- Gracefully handles malformed input (wrong segment count, invalid base64/JSON)

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
N/A