### PR TITLE
Add /api/health endpoint for uptime monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ The backend exposes a REST + WebSocket API. Application requests require an `X-A
 | `GET`  | `/api/scan/{id}/report/pdf` | PDF report |
 | `GET`  | `/api/scans` | List past scans (per-principal) |
 | `GET`  | `/healthz` | Unauthenticated health check |
+| `GET`  | `/api/health` | Unauthenticated health check for uptime monitors and load balancers |
 | `WS`   | `/ws/{scan_id}` | Live scan progress stream |
 | `POST` | `/api/ai/summary`, `/api/ai/chat` | AI summary and Q&A |
 | `POST` | `/api/url-scan`, `/api/mac-lookup`, `/api/crypto`, `/api/darkweb`, `/api/qr-decode`, `/api/email-headers`, `/api/metadata` | Standalone tools |

--- a/web/app.py
+++ b/web/app.py
@@ -609,6 +609,10 @@ async def _execute_scan(scan_id: str, target: str, scan_type: str, modules: list
 async def healthz():
     return {"status": "ok"}
 
+@app.get("/api/health")
+async def health():
+    return {"status": "ok", "version": app.version}
+
 @app.post("/api/scan", dependencies=[Depends(require_api_key)])
 @limiter.limit("10/minute")
 async def start_scan(request: Request, req: ScanRequest):


### PR DESCRIPTION
## Summary
Add a lightweight `GET /api/health` endpoint for uptime monitors and load balancers,as requested in #111 
## Changes
- Add `GET /api/health` route in `web/app.py`, placed right after the existing `/healthz` route.Return `{"status": "ok", "version": app.version}` and is unauthenticated,so it can be probed without an API key
- Document the new endpoint in the API table of `README.md`

The new endpoint is intentionally kept separate from `/healthz`: `/healthz` stays hidden from the API docs (`include_in_schema=False`), while `/api/health` is a documented public endpoint that also reports the running version, making it more useful for external monitoring tools.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed

Started the server locally with:
```bash
python -m uvicorn web.app:app --host 0.0.0.0 --port 8080 --reload --no-proxy-headers
```
`GET http://localhost:8080/api/health`  returns:
```json
{"status": "ok", "version": "2.4.0"}
```
HTTP 200,matching the acceptance criteria in #111.

I did not add a unit test for this endpoint since the issue didn't ask for one and the route is a trivial static response, but I'm happy to add one if you'd prefer.

## Screenshots
N/A - endpoint returns JSON, no UI changes.
