### PR TITLE
Add "Scan another" button to results screen (#138)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start --port 3000",
     "lint": "next lint",
-    "test:urls": "node scripts/test-api-url.mjs"
+    "test:urls": "node scripts/test-api-url.mjs",
+    "test:i18n": "node scripts/test-i18n-keys.mjs"
   },
   "dependencies": {
     "next": "^14.2.0",

--- a/frontend/scripts/test-i18n-keys.mjs
+++ b/frontend/scripts/test-i18n-keys.mjs
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict';
+import { readFile, readdir } from 'node:fs/promises';
+
+const messagesUrl = new URL('../src/messages/', import.meta.url);
+
+async function loadLocale(file) {
+  const source = await readFile(new URL(file, messagesUrl), 'utf8');
+  return JSON.parse(source);
+}
+
+const files = (await readdir(messagesUrl)).filter(f => f.endsWith('.json')).sort();
+assert.ok(files.length > 0, 'no locale files found in src/messages');
+
+// Keys that every locale must define for the results screen to render correctly.
+const REQUIRED_RESULTS_KEYS = ['htmlReport', 'pdfReport', 'jsonReport', 'csvReport', 'mdReport', 'scanAnother'];
+
+for (const file of files) {
+  const messages = await loadLocale(file);
+  const results = messages.results ?? {};
+  for (const key of REQUIRED_RESULTS_KEYS) {
+    const value = results[key];
+    assert.equal(typeof value, 'string', `${file}: results.${key} must be a string`);
+    assert.ok(value.trim().length > 0, `${file}: results.${key} must not be empty`);
+  }
+}
+
+console.log(`i18n key tests passed (${files.length} locales)`);

--- a/frontend/src/components/App.tsx
+++ b/frontend/src/components/App.tsx
@@ -236,7 +236,7 @@ export function App() {
             </>
           )}
           {view === 'results' && scanMeta && (
-            <ScanResults scan={scanMeta} />
+            <ScanResults scan={scanMeta} onHome={handleHome} />
           )}
           {view === 'compare' && compareIds && (
             <ScanComparison scanIdA={compareIds[0]} scanIdB={compareIds[1]} onBack={handleHome} />

--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -419,9 +419,9 @@ const TABS = [
   { id: 'ai', label: 'AI', icon: Brain },
 ];
 
-interface Props { scan: ScanMeta & { results: ScanResults }; }
+interface Props { scan: ScanMeta & { results: ScanResults }; onHome: () => void; }
 
-export function ScanResults({ scan }: Props) {
+export function ScanResults({ scan, onHome }: Props) {
   const { t: i18n, locale } = useTranslations();
   const [tab, setTab] = useState('findings');
   const [aiSummary, setAiSummary] = useState('');
@@ -773,6 +773,10 @@ export function ScanResults({ scan }: Props) {
           </div>
         </div>
         <div className="flex flex-wrap gap-2 sm:justify-end">
+          <button type="button" onClick={onHome}
+            className="btn-ghost text-[11px] h-8 px-3">
+            <Search size={11} /> {i18n('results.scanAnother')}
+          </button>
           <button type="button" onClick={() => openReport('html')} disabled={reportLoading !== null}
             className="btn-ghost text-[11px] h-8 px-3">
             {reportLoading === 'html' ? '...' : <ExternalLink size={11} />} {i18n('results.htmlReport')}

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -215,6 +215,7 @@
     "jsonReport": "JSON herunterladen",
     "csvReport": "CSV herunterladen",
     "mdReport": "Markdown herunterladen",
+    "scanAnother": "Neuer Scan",
     "tabs": {
       "findings": "Befunde",
       "whois": "WHOIS",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -215,6 +215,7 @@
     "jsonReport": "Download JSON",
     "csvReport": "Download CSV",
     "mdReport": "Download Markdown",
+    "scanAnother": "Scan another",
     "tabs": {
       "findings": "Findings",
       "whois": "WHOIS",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -92,7 +92,7 @@
   "progress": { "modulesLabel": "módulos", "initializing": "Inicializando escaneo…", "running": "Ejecutando…", "log": "Registro de progreso" },
   "results": {
     "htmlReport": "Informe HTML", "pdfReport": "Informe PDF", "jsonReport": "Descargar JSON",
-    "csvReport": "Descargar CSV", "mdReport": "Descargar Markdown",
+    "csvReport": "Descargar CSV", "mdReport": "Descargar Markdown", "scanAnother": "Escanear otro",
     "tabs": { "findings": "Hallazgos", "whois": "WHOIS", "dns": "DNS", "subdomains": "Subdominios", "accounts": "Cuentas", "threats": "Amenazas", "censys": "Censys", "darkweb": "Dark Web", "wayback": "Wayback", "email": "Correo", "dorks": "Dorks", "phone": "Teléfono", "telegram": "Telegram", "map": "Mapa", "graph": "Grafo", "json": "JSON", "ai": "IA" },
     "opsec": {
       "scoreLabel": "Puntuación OPSEC", "riskSuffix": "RIESGO",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -107,6 +107,7 @@
     "jsonReport": "Télécharger JSON",
     "csvReport": "Télécharger CSV",
     "mdReport": "Télécharger Markdown",
+    "scanAnother": "Nouvelle analyse",
     "tabs": {
       "findings": "Résultats",
       "whois": "WHOIS",

--- a/frontend/src/messages/it.json
+++ b/frontend/src/messages/it.json
@@ -215,6 +215,7 @@
     "jsonReport": "Scarica JSON",
     "csvReport": "Scarica CSV",
     "mdReport": "Scarica Markdown",
+    "scanAnother": "Nuova scansione",
     "tabs": {
       "findings": "Risultati",
       "whois": "WHOIS",

--- a/frontend/src/messages/pt.json
+++ b/frontend/src/messages/pt.json
@@ -215,6 +215,7 @@
     "jsonReport": "Baixar JSON",
     "csvReport": "Baixar CSV",
     "mdReport": "Baixar Markdown",
+    "scanAnother": "Nova verificação",
     "tabs": {
       "findings": "Resultados",
       "whois": "WHOIS",

--- a/frontend/src/messages/ru.json
+++ b/frontend/src/messages/ru.json
@@ -215,6 +215,7 @@
     "jsonReport": "Скачать JSON",
     "csvReport": "Скачать CSV",
     "mdReport": "Скачать Markdown",
+    "scanAnother": "Новое сканирование",
     "tabs": {
       "findings": "Находки",
       "whois": "WHOIS",


### PR DESCRIPTION
## Summary

Adds a **"Scan another"** button to the results screen header so users can start a fresh scan in one click, instead of only being able to reset via the top-bar logo. Resolves #138.

The button reuses the existing `handleHome` reset logic — **no new state and no new reset behavior** are introduced. `handleHome` was already wired to the Topbar; this just threads the same callback into `ScanResults` and renders a button for it.

## Changes

- `frontend/src/components/App.tsx` — pass the existing `handleHome` into `ScanResults` via a new `onHome` prop.
- `frontend/src/components/views/ScanResults.tsx` — accept `onHome` and render a `Scan another` button in the existing results-header action row (reusing the established `btn-ghost` styling and the already-imported `Search` icon).
- `frontend/src/messages/{en,es,de,fr,it,pt,ru}.json` — add the `results.scanAnother` i18n key to all 7 locales.
- `frontend/scripts/test-i18n-keys.mjs` + `test:i18n` npm script — a test (see below).

## Type of change
- [x] New feature

## Testing

**Automated:** Added `frontend/scripts/test-i18n-keys.mjs`, run via `npm run test:i18n`. It asserts every locale defines the required `results.*` report keys including the new `scanAnother`, guarding against a missing-translation regression for the new button.

This test deliberately follows the repo's **existing** frontend test convention (`scripts/test-api-url.mjs`, `node:assert`): it uses **only Node built-ins and adds zero dependencies**, so it introduces no supply-chain surface and needs no `npm install` to run.

```
$ npm run test:i18n
i18n key tests passed (7 locales)
```

**Manual:** Start a scan to completion, confirm the "Scan another" button appears in the results header and returns to the idle/scan screen. (The button→`onHome` wiring is simple prop-threading; the project currently has no React component-test harness to automate a click — see note below.)

- [x] I have tested these changes locally
- [x] I have added/updated tests as needed

## Note for maintainers: frontend has no test framework in CI

While adding tests I noticed `.github/workflows/ci.yml` runs **Python only** (flake8 + pytest + Docker smoke test) and never touches `frontend/`. There's no JS/React test runner in the repo, so behavioral tests like *"clicking the button calls the reset handler"* can't be expressed today.

Suggestion (out of scope for this PR): add a frontend test framework (e.g. **Vitest + @testing-library/react**) and a CI job that runs `next lint`, `next build`, and the frontend tests on PRs. That would let UI changes like this one be covered by real interaction tests rather than relying on manual verification. Happy to open a follow-up issue/PR for this if useful.

## Screenshots
<!-- Results header now leads with a "Scan another" button alongside the export buttons. -->
