### PR TITLE
fix: normalize scan targets before detection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,7 @@ jobs:
         run: |
           npm run test:urls
           npm run test:i18n
+          npm run test:scan-target
 
       - name: Build
         run: npm run build

--- a/cli.py
+++ b/cli.py
@@ -17,6 +17,20 @@ import config
 __version__ = "2.4.0"
 
 
+def normalize_target(target: str) -> str:
+    normalized = target.strip()
+    scheme_sep = normalized.find("://")
+    if scheme_sep != -1 and normalized[:scheme_sep].lower() in {"http", "https"}:
+        normalized = normalized[scheme_sep + 3:]
+    normalized = normalized.rstrip("/")
+
+    if "@" in normalized and not normalized.startswith("@"):
+        return normalized.lower()
+    if "." in normalized and not any(ch.isspace() for ch in normalized):
+        return normalized.lower()
+    return normalized
+
+
 def detect_type(target: str) -> str:
     if "@" in target:
         return "email"
@@ -294,7 +308,7 @@ def main(argv: Optional[List[str]] = None) -> None:
         sys.exit(1)
 
     if args.command == "scan":
-        target = args.target.strip()
+        target = normalize_target(args.target)
         scan_type = args.scan_type or detect_type(target)
         modules = [m.strip() for m in args.modules.split(",") if m.strip()] if args.modules else None
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,7 +8,8 @@
     "start": "next start --port 3000",
     "lint": "next lint",
     "test:urls": "node scripts/test-api-url.mjs",
-    "test:i18n": "node scripts/test-i18n-keys.mjs"
+    "test:i18n": "node scripts/test-i18n-keys.mjs",
+    "test:scan-target": "node scripts/test-scan-target.mjs"
   },
   "dependencies": {
     "next": "^14.2.0",

--- a/frontend/scripts/test-scan-target.mjs
+++ b/frontend/scripts/test-scan-target.mjs
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import ts from 'typescript';
+
+const sourcePath = path.resolve('src/lib/scan-target.ts');
+const compiled = ts.transpileModule(
+  await (await import('node:fs/promises')).readFile(sourcePath, 'utf8'),
+  {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      isolatedModules: true,
+    },
+    fileName: sourcePath,
+  },
+).outputText;
+
+const tmp = await mkdtemp(path.join(tmpdir(), 'prism-scan-target-test-'));
+try {
+  const modulePath = path.join(tmp, 'scan-target.mjs');
+  await writeFile(modulePath, compiled, 'utf8');
+  const { detectScanType, normalizeScanTarget } = await import(modulePath);
+
+  assert.equal(normalizeScanTarget(' Example.COM '), 'example.com');
+  assert.equal(normalizeScanTarget('https://Example.COM/'), 'example.com');
+  assert.equal(normalizeScanTarget('HTTP://Example.COM//'), 'example.com');
+  assert.equal(normalizeScanTarget(' User@Example.COM '), 'user@example.com');
+  assert.equal(normalizeScanTarget('+1 555 000 0000'), '+1 555 000 0000');
+  assert.equal(normalizeScanTarget('@MixedCaseUser'), '@MixedCaseUser');
+
+  assert.equal(detectScanType(' https://Example.COM/ '), 'domain');
+  assert.equal(detectScanType(' USER@Example.COM '), 'email');
+  assert.equal(detectScanType('+1 555 000 0000'), 'phone');
+  assert.equal(detectScanType('@MixedCaseUser'), 'username');
+
+  console.log('scan target normalization tests passed');
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}

--- a/frontend/src/components/views/IdleView.tsx
+++ b/frontend/src/components/views/IdleView.tsx
@@ -3,19 +3,10 @@ import { useEffect, useState } from 'react';
 import { FileText, Mail, Bitcoin, QrCode, ChevronRight, Globe, User, Phone, Shield, Database, Zap, Eye, Activity, Network, Hash, Binary, KeyRound, Search } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
 import { getPrismDemoMode } from '@/lib/prism-config';
+import { detectScanType, normalizeScanTarget } from '@/lib/scan-target';
 import { Logo } from '../Logo';
 import { MODULE_MAP } from '../Sidebar';
 import type { ToolMode, ScanType } from '@/lib/types';
-
-function detectScanType(value: string): ScanType {
-  const s = value.trim();
-  if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s)) return 'email';
-  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(s) || /^[0-9a-fA-F:]+:[0-9a-fA-F:]+$/.test(s)) return 'ip';
-  if (/^\+?[\d][\d\s().-]{6,}$/.test(s)) return 'phone';
-  if (s.startsWith('@')) return 'username';
-  if (s.includes('.') && !/\s/.test(s)) return 'domain';
-  return 'username';
-}
 
 const TOOL_IDS = ['metadata', 'headers', 'crypto', 'qr', 'mac', 'subnet', 'hash', 'encoder', 'jwt'] as const;
 type ToolId = typeof TOOL_IDS[number];
@@ -51,7 +42,7 @@ export function IdleView({ onTool, onScan }: Props) {
 
   const runQuickScan = (e: React.FormEvent) => {
     e.preventDefault();
-    const target = query.trim();
+    const target = normalizeScanTarget(query);
     if (!target) return;
     const type = detectScanType(target);
     onScan(target, type, MODULE_MAP[type]);

--- a/frontend/src/lib/scan-target.ts
+++ b/frontend/src/lib/scan-target.ts
@@ -1,0 +1,27 @@
+import type { ScanType } from './types';
+
+export function normalizeScanTarget(value: string): string {
+  let normalized = value.trim();
+  const schemeSep = normalized.indexOf('://');
+  if (schemeSep !== -1) {
+    const scheme = normalized.slice(0, schemeSep).toLowerCase();
+    if (scheme === 'http' || scheme === 'https') {
+      normalized = normalized.slice(schemeSep + 3);
+    }
+  }
+  normalized = normalized.replace(/\/+$/, '');
+
+  if (normalized.includes('@') && !normalized.startsWith('@')) return normalized.toLowerCase();
+  if (normalized.includes('.') && !/\s/.test(normalized)) return normalized.toLowerCase();
+  return normalized;
+}
+
+export function detectScanType(value: string): ScanType {
+  const s = normalizeScanTarget(value);
+  if (/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(s)) return 'email';
+  if (/^(\d{1,3}\.){3}\d{1,3}$/.test(s) || /^[0-9a-fA-F:]+:[0-9a-fA-F:]+$/.test(s)) return 'ip';
+  if (/^\+?[\d][\d\s().-]{6,}$/.test(s)) return 'phone';
+  if (s.startsWith('@')) return 'username';
+  if (s.includes('.') && !/\s/.test(s)) return 'domain';
+  return 'username';
+}

--- a/tests/test_cli_target_normalization.py
+++ b/tests/test_cli_target_normalization.py
@@ -1,0 +1,52 @@
+import pytest
+
+import cli
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (" Example.COM ", "example.com"),
+        ("https://Example.COM/", "example.com"),
+        ("HTTP://Example.COM//", "example.com"),
+        (" User@Example.COM ", "user@example.com"),
+        ("+1 555 000 0000", "+1 555 000 0000"),
+        ("@MixedCaseUser", "@MixedCaseUser"),
+    ],
+)
+def test_normalize_target(raw, expected):
+    assert cli.normalize_target(raw) == expected
+
+
+def test_detect_type_after_normalization():
+    normalized = cli.normalize_target(" https://Example.COM/ ")
+
+    assert normalized == "example.com"
+    assert cli.detect_type(normalized) == "domain"
+
+
+def test_cli_scan_normalizes_target_before_running(monkeypatch):
+    captured = {}
+
+    async def fake_run_scan(target, scan_type, modules, verbose=False):
+        captured.update(
+            target=target,
+            scan_type=scan_type,
+            modules=modules,
+            verbose=verbose,
+        )
+        return {"ok": True}
+
+    monkeypatch.setattr(cli, "run_scan", fake_run_scan)
+    monkeypatch.setattr(cli, "output_json", lambda results, path=None: None)
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main(["scan", " HTTPS://Example.COM/ ", "--quiet"])
+
+    assert exc.value.code == 0
+    assert captured == {
+        "target": "example.com",
+        "scan_type": "domain",
+        "modules": None,
+        "verbose": False,
+    }


### PR DESCRIPTION
## Summary
- Add shared scan target normalization for CLI and frontend quick scans.
- Strip leading `http(s)://`, trim trailing slashes, and lowercase domains/emails before type detection and scan execution.
- Add backend and frontend unit coverage for normalization and type detection cases.

## Why
Targets like ` HTTPS://Example.COM/ ` were sent into scans with the scheme/case/trailing slash intact. That could still detect as a domain, but downstream modules receive a malformed domain target.

## Test Plan
- [x] `unset PYTHONPATH && .venv/bin/python -m pytest tests/ -q`
- [x] `npm run test:urls`
- [x] `npm run test:i18n`
- [x] `npm run test:scan-target`
- [x] `npm run build`
- [x] `npm run lint`

Closes #142
