### PR TITLE
feat: aria-labels for buttons

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -149,7 +149,7 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isOpen, onCl
 
   return (
     <aside className={`fixed inset-y-0 left-0 z-50 w-64 bg-surface-1 border-r border-border-1 flex flex-col h-screen transform transition-transform duration-200 ease-in-out md:relative md:z-auto md:transform-none ${isOpen ? 'translate-x-0' : '-translate-x-full'}`}>
-      <button onClick={onClose} className="absolute top-3 right-3 md:hidden text-text-3 hover:text-text-1 p-1">✕</button>
+      <button onClick={onClose} className="absolute top-3 right-3 md:hidden text-text-3 hover:text-text-1 p-1" aria-label="Close sidebar">✕</button>
       <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-3">
         <div>
           <label className="text-[10px] font-semibold text-text-3 uppercase tracking-wider block mb-1.5">{t('sidebar.target')}</label>
@@ -227,7 +227,7 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isOpen, onCl
               {t('sidebar.recent')}
             </div>
             {recents.length > 0 && (
-              <button onClick={clearRecents} className="text-text-3 hover:text-red transition-colors">
+              <button onClick={clearRecents} className="text-text-3 hover:text-red transition-colors" aria-label="Clear recent scans">
                 <Trash2 size={10} />
               </button>
             )}
@@ -292,12 +292,13 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isOpen, onCl
   <button
     onClick={handleClearHistory}
     className="text-text-3 hover:text-red transition-colors"
+    aria-label="Clear scan history"
   >
     <Trash2 size={10} />
   </button>
 
 
-              <button onClick={fetchHistory} className="text-text-3 hover:text-text-2 transition-colors ml-auto">
+              <button onClick={fetchHistory} className="text-text-3 hover:text-text-2 transition-colors ml-auto" aria-label="Refresh history">
                 <RotateCcw size={10} className={historyLoading ? 'spin' : ''} />
               </button>
             </div>

--- a/frontend/src/components/Topbar.tsx
+++ b/frontend/src/components/Topbar.tsx
@@ -36,7 +36,7 @@ export function Topbar({ status, onHome, onMenuToggle }: Props) {
 
   return (
     <header className="h-12 flex items-center px-5 border-b border-border-1 bg-surface-1/80 backdrop-blur-sm sticky top-0 z-50">
-      <button onClick={onMenuToggle} className="md:hidden text-text-3 hover:text-text-1 transition-colors p-1 -ml-1">
+      <button onClick={onMenuToggle} className="md:hidden text-text-3 hover:text-text-1 transition-colors p-1 -ml-1" aria-label="Toggle menu">
         <Menu size={18} />
       </button>
 
@@ -135,6 +135,7 @@ export function Topbar({ status, onHome, onMenuToggle }: Props) {
           rel="noopener noreferrer"
           className="text-text-3 hover:text-text-1 transition-colors"
           title="GitHub"
+          aria-label="GitHub repository"
         >
           <Github size={15} />
         </a>

--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -1358,7 +1358,8 @@ export function ScanResults({ scan, onHome }: Props) {
                 <div key={i} className="flex items-center gap-2 py-1.5 border-b border-border-1 last:border-0">
                   <code className="font-mono text-[11px] text-text-1 flex-1 truncate">{d}</code>
                   <a href={`https://www.google.com/search?q=${encodeURIComponent(d)}`} target="_blank" rel="noreferrer"
-                    className="text-blue hover:text-white transition-colors flex-shrink-0">
+                    className="text-blue hover:text-white transition-colors flex-shrink-0"
+                    aria-label="Search on Google">
                     <ExternalLink size={11} />
                   </a>
                 </div>
@@ -1508,6 +1509,7 @@ export function ScanResults({ scan, onHome }: Props) {
                   onClick={sendChat}
                   disabled={!chatInput.trim() || chatLoading}
                   className="btn-primary px-3 h-9 shrink-0"
+                  aria-label="Send message"
                 >
                   <SendHorizontal size={13} />
                 </button>


### PR DESCRIPTION
## Summary
For #135 . Added aria-labels for icon-only buttons.

## Changes
Topbar.tsx - 2 changes
- Hamburger menu button → aria-label="Toggle menu"
- GitHub icon link → aria-label="GitHub repository"

Sidebar.tsx - 4 changes
- Close sidebar button → aria-label="Close sidebar"
- Clear recent scans button → aria-label="Clear recent scans"
- Clear scan history button → aria-label="Clear scan history"
- Refresh history button → aria-label="Refresh history"

ScanResults.tsx - 2 changes
- Google dork search link → aria-label="Search on Google"
- Send chat button → aria-label="Send message"

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
