### PR TITLE
feat: add Gravatar recon module for email scans

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -20,7 +20,7 @@ const SCAN_TYPES: ScanType[] = ['domain', 'ip', 'email', 'phone', 'username'];
 export const MODULE_MAP: Record<ScanType, string[]> = {
   domain:   ['whois', 'dns', 'geoip', 'cert_transparency', 'website', 'wayback', 'shodan', 'virustotal', 'censys', 'onion'],
   ip:       ['geoip', 'shodan', 'virustotal', 'abuseipdb', 'censys'],
-  email:    ['emailrep', 'smtp', 'leaks'],
+  email:    ['emailrep', 'smtp', 'leaks', 'gravatar'],
   phone:    ['hlr'],
   username: ['blackbird', 'maigret', 'github'],
 };

--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useState, useEffect, useRef } from 'react';
-import { ExternalLink, Printer, Download, Shield, AlertTriangle, Globe, Server, Lock, User, Clock, Zap, Phone, MessageCircle, Map, GitBranch, Code, Brain, ChevronDown, ChevronUp, SendHorizontal, Mail, Copy, Eye, ShieldAlert, ArrowUp, FileSpreadsheet, FileText, Search, RefreshCw, Loader2, Github } from 'lucide-react';
+import { ExternalLink, Printer, Download, Shield, AlertTriangle, Globe, Server, Lock, User, Clock, Zap, Phone, MessageCircle, Map, GitBranch, Code, Brain, ChevronDown, ChevronUp, SendHorizontal, Mail, Copy, Eye, ShieldAlert, ArrowUp, FileSpreadsheet, FileText, Search, RefreshCw, Loader2, Github, UserCircle } from 'lucide-react';
 import type { ScanResults, ScanMeta, OpsecFinding, ModuleStatus, ModuleStatusFields, ScanType } from '@/lib/types';
 import { fetchReportBlob, generateAiSummary, sendAiChat, getMapData, getGraphData, startScan, getScan } from '@/lib/api';
 import { useTranslations } from '@/lib/i18n';
@@ -410,6 +410,7 @@ const TABS = [
   { id: 'darkweb', label: 'Dark Web', icon: ShieldAlert },
   { id: 'wayback', label: 'Wayback', icon: Clock },
   { id: 'email', label: 'Email', icon: Mail },
+  { id: 'gravatar', label: 'Gravatar', icon: UserCircle },
   { id: 'dorks', label: 'Dorks', icon: Zap },
   { id: 'phone', label: 'Phone', icon: Phone },
   { id: 'telegram', label: 'Telegram', icon: MessageCircle },
@@ -729,7 +730,8 @@ export function ScanResults({ scan, onHome }: Props) {
     if (t.id === 'censys') return r.censys && modStatus(r.censys) === 'ok';
     if (t.id === 'darkweb') return r.onion && !r.onion.error && (r.onion.total_found ?? 0) > 0;
     if (t.id === 'wayback') return r.wayback;
-    if (t.id === 'email') return r.emailrep || r.smtp || r.breaches;
+    if (t.id === 'email') return r.emailrep || r.smtp || r.breaches || r.gravatar;
+    if (t.id === 'gravatar') return r.gravatar && modStatus(r.gravatar) === 'ok';
     if (t.id === 'dorks') return r.dorks?.length;
     if (t.id === 'phone') return r.phone;
     if (t.id === 'telegram') return r.telegram;
@@ -1324,6 +1326,62 @@ export function ScanResults({ scan, onHome }: Props) {
               </div>
             </KeyModuleCard>
           </div>
+        )}
+
+        {tab === 'gravatar' && (
+          <KeyModuleCard
+            title="Gravatar"
+            mod={r.gravatar}
+            onRefresh={() => refreshModule('gravatar')}
+            refreshing={isRefreshing('gravatar')}
+          >
+            <div className="space-y-3">
+              <div className="space-y-1.5">
+                <DtRow label="Display Name" value={r.gravatar?.display_name} />
+                  {r.gravatar?.avatar_url && (
+                    <div className="dt-row">
+                      <span className="dt-label">Avatar URL</span>
+                      <a
+                        href={r.gravatar.avatar_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-blue hover:underline"
+                      >
+                        {r.gravatar.avatar_url}
+                      </a>
+                    </div>
+                  )}
+              </div>
+
+              {(r.gravatar?.accounts?.length ?? 0) > 0 && (
+                <div className="space-y-1.5">
+                  {r.gravatar?.accounts?.map(account => (
+                    <div
+                      key={account.url ?? account.name ?? account.display}
+                      className="dt-row"
+                    >
+                      <span className="dt-label">
+                        {account.name ?? "Account"}
+                      </span>
+
+                      {account.url ? (
+                        <a
+                          href={account.url}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="text-blue hover:underline break-all"
+                        >
+                          {account.display || account.url}
+                        </a>
+                      ) : (
+                        <span>{account.display || "-"}</span>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </KeyModuleCard>
         )}
 
         {tab === 'dorks' && r.dorks && (

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -176,6 +176,19 @@ export interface BreachData extends ModuleStatusFields {
   error?: string;
 }
 
+export interface GravatarAccount {
+  name?: string;
+  display?: string;
+  url?: string;
+}
+
+export interface GravatarData extends ModuleStatusFields {
+  avatar_url?: string;
+  display_name?: string;
+  accounts?: GravatarAccount[];
+  error?: string;
+}
+
 export interface ScanResults {
   whois?: WhoisData;
   dns?: DnsRecord;
@@ -192,6 +205,7 @@ export interface ScanResults {
   emailrep?: EmailRepData;
   smtp?: SmtpData;
   breaches?: BreachData;
+  gravatar?: GravatarData;
   website?: Record<string, unknown>;
   dorks?: string[];
   censys?: CensysData;

--- a/frontend/src/messages/de.json
+++ b/frontend/src/messages/de.json
@@ -43,6 +43,7 @@
       "emailrep": "E-Mail-Rep",
       "smtp": "SMTP-Prüfung",
       "leaks": "Leak-Check",
+      "gravatar": "Gravatar",
       "hlr": "Telefon-Suche",
       "blackbird": "Blackbird",
       "maigret": "Maigret",

--- a/frontend/src/messages/en.json
+++ b/frontend/src/messages/en.json
@@ -43,6 +43,7 @@
       "emailrep": "Email Rep",
       "smtp": "SMTP Verify",
       "leaks": "Breach Check",
+      "gravatar": "Gravatar",
       "hlr": "Phone Lookup",
       "blackbird": "Blackbird",
       "maigret": "Maigret",

--- a/frontend/src/messages/es.json
+++ b/frontend/src/messages/es.json
@@ -32,6 +32,7 @@
       "emailrep": "Email Rep",
       "smtp": "Verif. SMTP",
       "leaks": "Filtraciones",
+      "gravatar": "Gravatar",
       "hlr": "Teléfono",
       "blackbird": "Blackbird",
       "maigret": "Maigret",

--- a/frontend/src/messages/fr.json
+++ b/frontend/src/messages/fr.json
@@ -32,6 +32,7 @@
       "emailrep": "Email Rep",
       "smtp": "Vérif. SMTP",
       "leaks": "Fuites",
+      "gravatar": "Gravatar",
       "hlr": "Téléphone",
       "blackbird": "Blackbird",
       "maigret": "Maigret",

--- a/frontend/src/messages/it.json
+++ b/frontend/src/messages/it.json
@@ -43,6 +43,7 @@
       "emailrep": "Rep. Email",
       "smtp": "Verifica SMTP",
       "leaks": "Violazioni",
+      "gravatar": "Gravatar",
       "hlr": "Ricerca telefono",
       "blackbird": "Blackbird",
       "maigret": "Maigret",

--- a/frontend/src/messages/pl.json
+++ b/frontend/src/messages/pl.json
@@ -43,6 +43,7 @@
       "emailrep": "Reputacja Email",
       "smtp": "Weryfikacja SMTP",
       "leaks": "Wycieki Danych",
+      "gravatar": "Gravatar",
       "hlr": "Informacje o Telefonie",
       "blackbird": "Blackbird",
       "maigret": "Maigret",

--- a/frontend/src/messages/pt.json
+++ b/frontend/src/messages/pt.json
@@ -43,6 +43,7 @@
       "emailrep": "Rep. E-mail",
       "smtp": "Verificar SMTP",
       "leaks": "Vazamentos",
+      "gravatar": "Gravatar",
       "hlr": "Consulta telefone",
       "blackbird": "Blackbird",
       "maigret": "Maigret",

--- a/frontend/src/messages/ru.json
+++ b/frontend/src/messages/ru.json
@@ -43,6 +43,7 @@
       "emailrep": "Репутация",
       "smtp": "SMTP проверка",
       "leaks": "Утечки",
+      "gravatar": "Gravatar",
       "hlr": "Поиск телефона",
       "blackbird": "Blackbird",
       "maigret": "Maigret",

--- a/modules/gravatar.py
+++ b/modules/gravatar.py
@@ -1,0 +1,126 @@
+import hashlib
+from typing import Dict, Any, List
+import requests
+import sys
+
+sys.path.append("..")
+
+from config import Colors
+from modules.module_status import (
+    annotate,
+    print_status_notice,
+    OK,
+    RATE_LIMITED,
+    ERROR,
+)
+
+class GravatarRecon:
+    """Public Gravatar profile lookup for an email address.
+
+    Uses the public Gravatar profile endpoint with a SHA-256 email hash.
+    No API key is required. HTTP 429 responses are reported as
+    `rate_limited`.
+    """
+
+    BASE_URL = "https://gravatar.com"
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Accept": "application/json",
+            "User-Agent": "PRISM-OSINT",
+        }
+
+    def lookup(self, email: str) -> Dict[str, Any]:
+        email = (email or "").strip().lower()
+
+        result: Dict[str, Any] = {
+            "email": email,
+            "avatar_url": None,
+            "display_name": None,
+            "accounts": [],
+            "error": None,
+        }
+
+        if not email:
+            return annotate(result, ERROR, "No email provided")
+
+        email_hash = hashlib.sha256(email.encode("utf-8")).hexdigest()
+        try:
+            r = requests.get(
+                f"{self.BASE_URL}/{email_hash}.json",
+                headers=self._headers(),
+                timeout=15,
+            )
+
+            if r.status_code == 404:
+                return annotate(result, ERROR, "Gravatar profile not found")
+
+            if r.status_code == 429:
+                return annotate(
+                    result,
+                    RATE_LIMITED,
+                    "Gravatar API rate limit reached",
+                )
+
+            if r.status_code != 200:
+                return annotate(
+                    result,
+                    ERROR,
+                    f"Gravatar API returned {r.status_code}",
+                )
+
+            data = r.json()
+            entries = data.get("entry") or []
+
+            if not entries:
+                return annotate(result, ERROR, "Gravatar profile not found")
+
+            profile = entries[0]
+
+            result["avatar_url"] = profile.get("thumbnailUrl")
+            result["display_name"] = profile.get("displayName")
+            result["accounts"] = profile.get("accounts", [])
+
+            result["status"] = OK
+
+        except Exception as e:
+            return annotate(result, ERROR, str(e)[:200])
+
+        return result
+
+    def print_result(self, result: Dict[str, Any]) -> None:
+        print(f"\n{Colors.CYAN}{'=' * 60}{Colors.RESET}")
+        print(f"{Colors.BOLD}Gravatar Recon: {result.get('email')}{Colors.RESET}")
+        print(f"{Colors.CYAN}{'=' * 60}{Colors.RESET}")
+
+        if print_status_notice(result):
+            return
+
+        if result.get("error"):
+            print(f"{Colors.RED}Error: {result['error']}{Colors.RESET}")
+            return
+
+        print(
+            f"{Colors.YELLOW}Display Name:{Colors.RESET} "
+            f"{result.get('display_name') or 'N/A'}"
+        )
+
+        print(
+            f"{Colors.YELLOW}Avatar:{Colors.RESET} "
+            f"{result.get('avatar_url') or 'N/A'}"
+        )
+
+        accounts: List[Dict[str, Any]] = result.get("accounts") or []
+
+        if accounts:
+            print(f"{Colors.YELLOW}Linked Accounts:{Colors.RESET}")
+
+            for account in accounts:
+                name = account.get("name") or "Unknown"
+                display = account.get("display") or account.get("username") or ""
+                url = account.get("url") or ""
+
+                print(f"  • {name}: {display}")
+
+                if url:
+                    print(f"    {url}")

--- a/tests/test_gravatar.py
+++ b/tests/test_gravatar.py
@@ -1,0 +1,118 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from modules.gravatar import GravatarRecon
+from modules.module_status import classify, OK, RATE_LIMITED, ERROR
+
+
+class _Resp:
+    def __init__(self, status_code, data):
+        self.status_code = status_code
+        self._data = data
+
+    def json(self):
+        return self._data
+
+
+def test_lookup_success(monkeypatch):
+    import requests
+
+    def fake_get(url, **kwargs):
+        return _Resp(
+            200,
+            {
+                "entry": [
+                    {
+                        "displayName": "Beau Lebens",
+                        "thumbnailUrl": "https://0.gravatar.com/avatar/example",
+                        "accounts": [
+                            {
+                                "name": "GitHub",
+                                "display": "beaulebens",
+                                "url": "https://github.com/beaulebens",
+                            },
+                            {
+                                "name": "X",
+                                "display": "@beaulebens",
+                                "url": "https://x.com/beaulebens",
+                            },
+                        ],
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(requests, "get", fake_get)
+
+    r = GravatarRecon().lookup("beau@automattic.com")
+
+    assert classify(r) == OK
+    assert r["email"] == "beau@automattic.com"
+    assert r["display_name"] == "Beau Lebens"
+    assert r["avatar_url"] == "https://0.gravatar.com/avatar/example"
+    assert len(r["accounts"]) == 2
+    assert r["accounts"][0]["name"] == "GitHub"
+    assert r["error"] is None
+
+
+def test_lookup_not_found(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _Resp(404, {}))
+
+    r = GravatarRecon().lookup("missing@example.com")
+
+    assert r["error"] == "Gravatar profile not found"
+    assert r["display_name"] is None
+    assert r["avatar_url"] is None
+    assert r["accounts"] == []
+
+
+def test_lookup_rate_limited(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(requests, "get", lambda url, **kw: _Resp(429, {}))
+
+    r = GravatarRecon().lookup("beau@automattic.com")
+
+    assert classify(r) == RATE_LIMITED
+    assert r["error"] is None
+
+
+def test_lookup_empty_email():
+    r = GravatarRecon().lookup("")
+
+    assert classify(r) == ERROR
+    assert r["error"] == "No email provided"
+
+
+def test_lookup_empty_entry(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda url, **kw: _Resp(200, {"entry": []}),
+    )
+
+    r = GravatarRecon().lookup("beau@automattic.com")
+
+    assert r["error"] == "Gravatar profile not found"
+    assert r["accounts"] == []
+
+
+def test_lookup_server_error(monkeypatch):
+    import requests
+
+    monkeypatch.setattr(
+        requests,
+        "get",
+        lambda url, **kw: _Resp(500, {}),
+    )
+
+    r = GravatarRecon().lookup("beau@automattic.com")
+
+    assert classify(r) == ERROR
+    assert "Gravatar API returned 500" in r["error"]

--- a/web/app.py
+++ b/web/app.py
@@ -502,6 +502,12 @@ async def _execute_scan(scan_id: str, target: str, scan_type: str, modules: list
                 results["emailrep"] = await _run_module(
                     scan_id, "emailrep", EmailRepLookup().lookup, target
                 )
+            
+            if want("gravatar"):
+                from modules.gravatar import GravatarRecon
+                results["gravatar"] = await _run_module(
+                    scan_id, "gravatar", GravatarRecon().lookup, target
+                )
 
         elif scan_type == "phone":
             if want("hlr"):


### PR DESCRIPTION
## Summary
Adds a new GravatarRecon module to email scans. The module resolves a public Gravatar profile from an email address and returns the avatar URL, display name, and linked accounts. It follows the existing `module_status` pattern and integrates the results into the dashboard with a dedicated Gravatar tab.

The implementation uses a **SHA-256** hash of the normalized email when querying Gravatar's public profile endpoint, matching the issue's specified **MD5/SHA-256** hashing requirement while requiring no API key.

Closes #125

## Changes
- Added `modules/gravatar.py` for public Gravatar profile lookups
- Integrated Gravatar into the email scan pipeline in `web/app.py`
- Added Gravatar module label in sidebar for email scans
- Added support for Gravatar results in the frontend types
- Added a dedicated Gravatar tab to the dashboard (shown only when a profile is found)
- Displayed avatar URL, display name, and linked accounts in the UI
- Added localization strings for the new module across all supported languages
- Added unit tests for:
  - Successful profile lookup
  - Profile not found
  - API rate limiting
  - Empty email input

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as needed

### Tested
- Verified successful Gravatar lookups for emails with public profiles
- Verified behavior when no Gravatar profile exists
- Verified frontend integration and dashboard rendering
- Ran `pytest tests/test_gravatar.py`

## Screenshots
<img width="1607" height="542" alt="image" src="https://github.com/user-attachments/assets/e5334aff-5bfd-4b0b-be09-31d96f3d5dfa" />
