### PR TITLE
Add custom 404 page to frontend

### DIFF
--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+import { Logo } from '@/components/Logo';
+
+export default function NotFound() {
+  return (
+    <main className="flex min-h-screen items-center justify-center px-6">
+      <div className="flex flex-col items-center text-center">
+        <Logo size={72} animated/>
+
+        <h1 className="mt-6 text-7xl font-bold tracking-tight text-text-1">
+            404
+        </h1>
+
+        <p className="mt-3 text-2xl font-semibold text-text-1">
+            Page not found
+        </p>
+
+        <p className="mt-3 max-w-xl text-base text-text-2">
+            The page you&#39;re looking for doesn&#39;t exist or may have been moved.
+        </p>
+
+        <Link href="/" className="btn-primary mt-8">
+          Back to Home
+        </Link>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
Adds a custom 404 page for the frontend to replace the default Next.js not-found page.

Closes #112.

## Changes
* Added `frontend/src/app/not-found.tsx`
* Reused the existing `Logo` component and added centered "404 - page not found" message
* Added a link back to the homepage
* Used the existing Tailwind styles to match the application's theme

## Type of change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

## Testing
* [x] Tested locally by visiting an unknown route and verifying the custom 404 page is displayed
* [ ] I have added/updated tests as needed

## Screenshots
<img width="1919" height="884" alt="image" src="https://github.com/user-attachments/assets/ed2546ce-55e0-439a-bb06-15a8b78eb0f7" />
