### PR TITLE
test: add Base64 and URL encoder coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
           npm run test:urls
           npm run test:i18n
           npm run test:scan-target
+          npm run test:encoder
 
       - name: Build
         run: npm run build

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "test:urls": "node scripts/test-api-url.mjs",
     "test:i18n": "node scripts/test-i18n-keys.mjs",
-    "test:scan-target": "node scripts/test-scan-target.mjs"
+    "test:scan-target": "node scripts/test-scan-target.mjs",
+    "test:encoder": "node scripts/test-encoder.mjs"
   },
   "dependencies": {
     "next": "^14.2.0",

--- a/frontend/scripts/test-encoder.mjs
+++ b/frontend/scripts/test-encoder.mjs
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import ts from 'typescript';
+
+const sourcePath = path.resolve('src/lib/encoder-utils.ts');
+const compiled = ts.transpileModule(
+  await readFile(sourcePath, 'utf8'),
+  {
+    compilerOptions: {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2022,
+      isolatedModules: true,
+    },
+    fileName: sourcePath,
+  },
+).outputText;
+
+const tmp = await mkdtemp(path.join(tmpdir(), 'prism-encoder-test-'));
+
+try {
+  const modulePath = path.join(tmp, 'encoder-utils.mjs');
+  await writeFile(modulePath, compiled, 'utf8');
+
+  const { runEncoder } = await import(pathToFileURL(modulePath).href);
+
+  assert.equal(runEncoder('', 'base64', 'encode'), '');
+  assert.equal(runEncoder('', 'base64', 'decode'), '');
+  assert.equal(runEncoder('', 'url', 'encode'), '');
+  assert.equal(runEncoder('', 'url', 'decode'), '');
+
+  assert.equal(runEncoder('hello', 'base64', 'encode'), 'aGVsbG8=');
+  assert.equal(runEncoder('aGVsbG8=', 'base64', 'decode'), 'hello');
+
+  const base64Cases = [
+    'hello world',
+    'café 🚀',
+    'symbols + % / = ? &',
+  ];
+
+  for (const value of base64Cases) {
+    const encoded = runEncoder(value, 'base64', 'encode');
+    const decoded = runEncoder(encoded, 'base64', 'decode');
+    assert.equal(decoded, value, `Base64 round trip failed for: ${value}`);
+  }
+
+  assert.throws(
+    () => runEncoder('not-valid-base64%%%', 'base64', 'decode'),
+    undefined,
+    'Invalid Base64 input should throw',
+  );
+
+  const urlCases = [
+    'hello world',
+    'café 🚀',
+    'a+b%c',
+    'email=test@example.com&redirect=/a b',
+  ];
+
+  for (const value of urlCases) {
+    const encoded = runEncoder(value, 'url', 'encode');
+    const decoded = runEncoder(encoded, 'url', 'decode');
+    assert.equal(decoded, value, `URL round trip failed for: ${value}`);
+  }
+
+  assert.equal(runEncoder('hello world', 'url', 'encode'), 'hello%20world');
+  assert.equal(runEncoder('a+b%c', 'url', 'encode'), 'a%2Bb%25c');
+  assert.equal(runEncoder('café', 'url', 'encode'), 'caf%C3%A9');
+  assert.equal(runEncoder('a+b', 'url', 'decode'), 'a+b');
+
+  assert.throws(
+    () => runEncoder('%E0%A4%A', 'url', 'decode'),
+    undefined,
+    'Malformed URL encoding should throw',
+  );
+
+  console.log('encoder tests passed');
+} finally {
+  await rm(tmp, { recursive: true, force: true });
+}

--- a/frontend/src/components/tools/ToolPanels.tsx
+++ b/frontend/src/components/tools/ToolPanels.tsx
@@ -2,6 +2,7 @@
 import { useState, useCallback } from 'react';
 import { Loader2, ArrowLeft, ExternalLink, Upload, XCircle, FileUp } from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
+import { runEncoder, type EncoderMode } from '@/lib/encoder-utils';
 import * as api from '@/lib/api';
 import type { ToolMode, CryptoResult, QrResult, HeaderAnalysisResult, MetaResult, MacResult } from '@/lib/types';
 
@@ -359,20 +360,14 @@ function EncoderPanel() {
   const [input, setInput] = useState('');
   const [output, setOutput] = useState('');
   const [error, setError] = useState('');
-  const [mode, setMode] = useState<'base64' | 'url'>('base64');
+  const [mode, setMode] = useState<EncoderMode>('base64');
 
   const run = (op: 'encode' | 'decode') => {
     setError('');
     setOutput('');
     if (!input) return;
     try {
-      if (mode === 'base64') {
-        setOutput(op === 'encode'
-          ? btoa(unescape(encodeURIComponent(input)))
-          : decodeURIComponent(escape(atob(input))));
-      } else {
-        setOutput(op === 'encode' ? encodeURIComponent(input) : decodeURIComponent(input));
-      }
+      setOutput(runEncoder(input, mode, op));
     } catch {
       setError(t('toolPanels.encoder.invalid'));
     }

--- a/frontend/src/lib/encoder-utils.ts
+++ b/frontend/src/lib/encoder-utils.ts
@@ -1,0 +1,21 @@
+export type EncoderMode = 'base64' | 'url';
+export type EncoderOperation = 'encode' | 'decode';
+
+export function runEncoder(
+  input: string,
+  mode: EncoderMode,
+  operation: EncoderOperation,
+): string {
+  if (!input) return '';
+
+  if (mode === 'base64') {
+    // Keep the tool's existing UTF-8 Base64 behavior while making it testable
+    return operation === 'encode'
+      ? btoa(unescape(encodeURIComponent(input)))
+      : decodeURIComponent(escape(atob(input)));
+  }
+
+  return operation === 'encode'
+    ? encodeURIComponent(input)
+    : decodeURIComponent(input);
+}


### PR DESCRIPTION
## Summary

- Extracted the Base64/URL encoder logic into a small utility so it can be tested directly.
- Added frontend coverage for Base64 and URL encoding/decoding.
- Covered round trips, invalid input handling, empty input, unicode, spaces, `+`, and `%` edge cases.
- Added `test:encoder` and included it in CI.

## Tests

- `npm run test:encoder`
- `npm run test:urls`
- `npm run test:i18n`
- `npx tsc --noEmit`
- `npm run lint`
- `pytest tests/ -v --basetemp=.pytest-tmp`

Closes #143