### PR TITLE
feat(frontend): add human-readable watchlist alert labels

### DIFF
--- a/frontend/src/components/views/WatchlistView.tsx
+++ b/frontend/src/components/views/WatchlistView.tsx
@@ -4,6 +4,7 @@ import { Eye, Plus, Trash2, Bell, Clock, RefreshCw, ChevronDown, ChevronUp, Aler
 import { listWatchlists, createWatchlist, deleteWatchlist } from '@/lib/api';
 import { useTranslations } from '@/lib/i18n';
 import type { Watchlist, ScanType } from '@/lib/types';
+import { formatWatchlistChange } from '@/lib/watchlist-alert-utils';
 
 const SCAN_TYPES: (ScanType | 'auto')[] = ['auto', 'domain', 'ip', 'email', 'phone', 'username'];
 
@@ -195,7 +196,7 @@ export function WatchlistView({ onBack }: { onBack: () => void }) {
                             {fmtTime(a.at)} · <span className="text-green">+{a.added_count}</span> / <span className="text-red">−{a.removed_count}</span> {t('watchlist.changes')}
                           </div>
                           <div className="font-mono space-y-0.5">
-                            {a.added.map((c, j) => <div key={`a${j}`} className="text-green break-all">+ {c}</div>)}
+                            {a.added.map((c, j) => <div key={`a${j}`} className="text-green break-all">+ {formatWatchlistChange(c)}</div>)}
                             {a.removed.map((c, j) => <div key={`r${j}`} className="text-red break-all">− {c}</div>)}
                           </div>
                         </div>

--- a/frontend/src/lib/watchlist-alert-utils.ts
+++ b/frontend/src/lib/watchlist-alert-utils.ts
@@ -1,0 +1,17 @@
+const WATCHLIST_CHANGE_LABELS: Record<string, string> = {
+  'shodan.open_ports[]': 'New open port',
+  'cert_transparency.subdomains[]': 'New subdomain',
+  'breaches.breaches[].name': 'New breach found',
+  'breaches.breaches[].title': 'New breach found'
+}
+
+export function formatWatchlistChange(rawFingerprintPath: string): string {
+  const [path, value = ''] = rawFingerprintPath.split('=');
+  const label = WATCHLIST_CHANGE_LABELS[path];
+
+  if (!label) {
+    return rawFingerprintPath;
+  }
+
+  return value ? `${label}: ${value}` : label;
+}


### PR DESCRIPTION
## Summary
From Issue [#155](https://github.com/NovaCode37/Prism-platform/issues/155).

Add human-readable labels for the most common watchlist change alert fingerprint paths.

## Changes
- Added a mapping for the most common watchlist alert paths:
  - `shodan.open_ports[]=22` → `New open port: 22`
  - `cert_transparency.subdomains[]=x` → `New subdomain: x`
  - `breaches.breaches[].name=a` → `New breach found: a`
  - `breaches.breaches[].title=b` → `New breach found: b`
- Kept raw fingerprint text as fallback for unmapped paths.

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [x] I have run `npm run build`

## Open Questions
- Should removed alerts also use human-readable labels, or only added alerts?
- For breach alerts, should we support both `breaches.breaches[].name` and `breaches.breaches[].title`? Should we show the breach name/title after `New breach found`?
- Should these labels be added to the i18n message files, or can they stay as plain English text for now?

## Screenshots
Screenshot uses Python-generated local watchlist JSON fixture data. It shows mapped added alerts (`New subdomain`) and raw fallback for unmapped paths. Removed entries are currently left as raw paths pending maintainer clarification.
<img width="1974" height="1432" alt="" src="https://github.com/user-attachments/assets/246c6400-6bdc-4c28-ab08-be2eaab1a142" />