### PR TITLE
feat(graph): add legend to entity graph (closes #205)

### DIFF
--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -194,6 +194,37 @@ function MapView({ scanId, onCopy }: { scanId: string; onCopy: (value: string) =
   );
 }
 
+// Mirrors NODE_COLORS + _shape in modules/graph_builder.py exactly.
+const LEGEND_ITEMS = [
+  { type: 'target',        color: '#00d4ff', label: 'Target' },
+  { type: 'email',         color: '#ff9f43', label: 'Email' },
+  { type: 'domain',        color: '#a29bfe', label: 'Domain' },
+  { type: 'subdomain',     color: '#74b9ff', label: 'Subdomain' },
+  { type: 'ip',            color: '#fd79a8', label: 'IP Address' },
+  { type: 'account',       color: '#55efc4', label: 'Account' },
+  { type: 'technology',    color: '#636e72', label: 'Technology' },
+  { type: 'vulnerability', color: '#d63031', label: 'Vulnerability' },
+  { type: 'organization',  color: '#fdcb6e', label: 'Organization' },
+  { type: 'url',           color: '#81ecec', label: 'URL' },
+] as const;
+
+function GraphLegend() {
+  return (
+    <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 px-1">
+      {LEGEND_ITEMS.map(({ type, color, label }) => (
+        <div key={type} className="flex items-center gap-1.5">
+          <span
+            className="inline-block h-2.5 w-2.5 rounded-full shrink-0"
+            style={{ background: color }}
+            aria-hidden
+          />
+          <span className="text-[11px] text-text-3 capitalize">{label}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function GraphView({ scanId }: { scanId: string }) {
   const { t } = useTranslations();
   const containerRef = useRef<HTMLDivElement>(null);
@@ -248,6 +279,7 @@ function GraphView({ scanId }: { scanId: string }) {
       )}
       {status === 'error' && <div className="text-red text-sm py-4">{error}</div>}
       <div ref={containerRef} className="h-72 sm:h-[480px]" style={{ height: status === 'ready' ? undefined : 0, background: 'transparent' }} />
+      {status === 'ready' && <GraphLegend />}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Adds a legend below the entity graph so users can easily identify each node type by its color.

This implementation follows the existing frontend graph styling and does not require any backend or API changes.

## Changes

- Added a lightweight `GraphLegend` component inside `ScanResults.tsx`
- Mirrored the existing `NODE_COLORS` mapping from `graph_builder.py`
- Displays all supported entity types:
  - Target
  - Email
  - Domain
  - Subdomain
  - IP Address
  - Account
  - Technology
  - Vulnerability
  - Organization
  - URL
- Uses the exact same hex colors as the graph nodes
- Uses a responsive `flex-wrap` layout for smaller screens
- Only renders when the graph status is `ready`
- No new dependencies
- No backend or API changes

## Why

The graph already uses distinct colors for different entity types, but users currently have no way to identify what each color represents. Adding a legend improves usability and makes the visualization much easier to understand.

## Testing

- ✅ Legend appears only after the graph has successfully loaded
- ✅ Colors match the node colors in the graph
- ✅ Responsive on narrow screen widths
- ✅ Hidden during loading, empty, and error states

Closes #205