### PR TITLE
feat: add Report an Issue link to Topbar (#202)

### DIFF
--- a/frontend/src/components/Topbar.tsx
+++ b/frontend/src/components/Topbar.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { Loader2, CheckCircle, XCircle, Github, Star, Terminal, Sun, Moon, Menu, Languages, Book, Eye, Puzzle } from 'lucide-react';
+import { Loader2, CheckCircle, XCircle, Github, Star, Terminal, Sun, Moon, Menu, Languages, Book, Eye, Puzzle, AlertCircle } from 'lucide-react';
 import { useTheme } from '@/lib/useTheme';
 import { useTranslations, SUPPORTED_LOCALES } from '@/lib/i18n';
 import { Logo } from './Logo';
@@ -146,19 +146,28 @@ export function Topbar({ status, usage, onHome, onWatchlist, onMenuToggle }: Pro
         >
           <Book size={15} />
         </a>
-
-            <a
-  href="https://github.com/NovaCode37/Prism-platform"
-  target="_blank"
-  rel="noopener noreferrer"
-  className="flex items-center gap-1 text-text-3 hover:text-text-1 transition-colors text-[11px]"
-  title="Star on GitHub"
-  aria-label="Star on GitHub"
->
-  <Star size={15} />
-  <span className="hidden sm:inline">Star</span>
-</a>
-
+        <a
+          href="https://github.com/NovaCode37/Prism-platform/issues/new"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-text-3 hover:text-text-1 transition-colors text-[11px]"
+          title="Report an issue"
+          aria-label="Report an issue"
+        >
+          <AlertCircle size={15} />
+          <span className="hidden sm:inline">Report</span>
+        </a>
+        <a
+          href="https://github.com/NovaCode37/Prism-platform"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-1 text-text-3 hover:text-text-1 transition-colors text-[11px]"
+          title="Star on GitHub"
+          aria-label="Star on GitHub"
+        >
+          <Star size={15} />
+          <span className="hidden sm:inline">Star</span>
+        </a>
         <a
           href="https://github.com/NovaCode37/Prism-platform"
           target="_blank"


### PR DESCRIPTION
Closes #202

## Summary
Adds a small "Report an issue" link to the Topbar, placed between the API docs icon and the Star link — unobtrusive and consistent with the existing icon row.

## Changes
- Added `AlertCircle` to the lucide-react import
- Added an `<a>` link pointing to `/issues/new` with icon + "Report" label (hidden on mobile, visible on sm+)
- Also cleaned up the inconsistent indentation on the Star link block (pre-existing issue)

## How to test
1. Run `npm run dev` in `frontend/`
2. Check the topbar — "Report" link appears between Extension and Star
3. Click it → opens `https://github.com/NovaCode37/Prism-platform/issues/new` in a new tab