### PR TITLE
Add light mode support for extension popup and scan page

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -56,3 +56,86 @@ hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
 .full { display: block; text-align: center; margin-top: 14px; padding: 8px; background: #21262d; color: #adbac7; border-radius: 6px; text-decoration: none; font-size: 12px; }
 .full:hover { background: #2d333b; color: #fff; }
 .error { color: #f85149; background: #161b22; border: 1px solid #3d1518; border-radius: 8px; padding: 12px; font-size: 12px; }
+@media (prefers-color-scheme: light) {
+
+  body {
+    background: #ffffff;
+    color: #24292f;
+  }
+
+  label,
+  .note,
+  .status,
+  .section-title,
+  .row .k,
+  .opsec .meta {
+    color: #424a53;
+  }
+
+  input {
+    background: #f6f8fa;
+    border-color: #d0d7de;
+    color: #24292f;
+  }
+
+  input::placeholder {
+    color: #656d76;
+  }
+
+  .ghost {
+    border-color: #d0d7de;
+    color: #424a53;
+  }
+
+  .ghost:hover {
+    border-color: #b1bac4;
+  }
+
+  hr {
+    border-top-color: #d8dee4;
+  }
+
+  .bar-wrap,
+  .card,
+  .opsec,
+  .error {
+    background: #f6f8fa;
+    border-color: #d0d7de;
+  }
+
+  .finding {
+    border-bottom-color: #d8dee4;
+  }
+
+  .tag {
+    background: #eaeef2;
+    color: #24292f;
+  }
+
+  .row .v,
+  .scan-target {
+    color: #24292f;
+  }
+
+  .back {
+    color: #656d76;
+  }
+
+  .back:hover {
+    color: #24292f;
+  }
+
+  .full {
+    background: #eaeef2;
+    color: #24292f;
+  }
+
+  .full:hover {
+    background: #d8dee4;
+  }
+
+  .empty {
+    color: #656d76;
+  }
+
+}

--- a/extension/scan.css
+++ b/extension/scan.css
@@ -52,3 +52,53 @@ body {
 .full { display: inline-block; margin-top: 26px; padding: 9px 16px; background: #21262d; color: #adbac7; border-radius: 6px; text-decoration: none; font-size: 13px; }
 .full:hover { background: #2d333b; color: #fff; }
 .error { color: #f85149; background: #161b22; border: 1px solid #3d1518; border-radius: 8px; padding: 14px; font-size: 13px; }
+@media (prefers-color-scheme: light) {
+
+  body {
+    background: #ffffff;
+    color: #24292f;
+  }
+
+  .brand,
+  .section-title,
+  .status,
+  .row .k,
+  .opsec .meta,
+  .log,
+  .empty {
+    color: #656d76;
+  }
+
+  .target,
+  .card h3,
+  .row .v {
+    color: #24292f;
+  }
+
+  .bar-wrap,
+  .card,
+  .opsec,
+  .error {
+    background: #f6f8fa;
+    border-color: #d0d7de;
+  }
+
+  .finding {
+    border-bottom-color: #d8dee4;
+  }
+
+  .tag {
+    background: #eaeef2;
+    color: #24292f;
+  }
+
+  .full {
+    background: #eaeef2;
+    color: #24292f;
+  }
+
+  .full:hover {
+    background: #d8dee4;
+    color: #24292f;
+  }
+}


### PR DESCRIPTION
## Summary
Added light mode support for the extension popup and scan page so the extension follows the user's system theme.

## Changes
- Added `@media (prefers-color-scheme: light)` block in `extension/popup.css`
- Added light theme styles for backgrounds, text, inputs, borders, cards, and buttons
- Added matching light mode support in `extension/scan.css`
- Matched the colors with the existing web UI light theme palette

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
Tested the extension popup and scan page in both:
- Windows Light mode
- 
<img width="556" height="520" alt="Screenshot 2026-07-27 221925" src="https://github.com/user-attachments/assets/aacf11d9-607e-40ea-941e-45fcc0c0c1e6" />

- Windows Dark mode
<img width="513" height="505" alt="Screenshot 2026-07-27 221852" src="https://github.com/user-attachments/assets/8b4370fb-4d5d-4d00-b198-68fc3eb87f90" />

Both themes switch correctly based on the system theme.

