### PR TITLE
Fix spacing: two blank lines before __main__ block

### DIFF
--- a/modules/hunter.py
+++ b/modules/hunter.py
@@ -197,5 +197,7 @@ def run_emailrep():
 run_hunter_domain = run_emailrep
 run_hunter_email = run_emailrep
 
+
+
 if __name__ == "__main__":
     run_emailrep()

--- a/modules/hunter.py
+++ b/modules/hunter.py
@@ -198,6 +198,5 @@ run_hunter_domain = run_emailrep
 run_hunter_email = run_emailrep
 
 
-
 if __name__ == "__main__":
     run_emailrep()


### PR DESCRIPTION
Small style fix in modules/hunter.py — added the missing
blank line before the __main__ block to match PEP 8 spacing
(two blank lines between top-level definitions), per CONTRIBUTING.md.