### PR TITLE
fix(extension): style severity badges in light mode

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -107,6 +107,23 @@ hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
     border-bottom-color: #d8dee4;
   }
 
+  .sev.CRITICAL,
+  .sev.HIGH {
+    background: #ffebe9;
+    color: #cf222e;
+  }
+
+  .sev.MEDIUM {
+    background: #fff8c5;
+    color: #9a6700;
+  }
+
+  .sev.LOW,
+  .sev.INFO {
+    background: #ddf4ff;
+    color: #0969da;
+  }
+
   .tag {
     background: #eaeef2;
     color: #24292f;

--- a/extension/scan.css
+++ b/extension/scan.css
@@ -87,6 +87,23 @@ body {
     border-bottom-color: #d8dee4;
   }
 
+  .sev.CRITICAL,
+  .sev.HIGH {
+    background: #ffebe9;
+    color: #cf222e;
+  }
+
+  .sev.MEDIUM {
+    background: #fff8c5;
+    color: #9a6700;
+  }
+
+  .sev.LOW,
+  .sev.INFO {
+    background: #ddf4ff;
+    color: #0969da;
+  }
+
   .tag {
     background: #eaeef2;
     color: #24292f;


### PR DESCRIPTION
## Summary

I added light-mode colors for the extension's severity badges so they match the surrounding light cards while retaining each severity's red, amber, or blue meaning.

## Changes

- I added GitHub-light background and text pairs for critical/high, medium, and low/info badges.
- I applied the same overrides to both the popup and full scan views.
- I kept the existing dark-mode colors unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] I tested both stylesheets with a focused assertion for selectors, light-mode placement, balanced braces, final newlines, and the expected color pairs.
- [x] I verified every new foreground/background pair has at least 4.5:1 contrast.
- [x] I ran `git diff --check`.

Fixes #246
