### PR TITLE
Add copy-to-clipboard button on extension result cards

### DIFF
--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -52,5 +52,11 @@
   },
   "openFull": {
     "message": "Open full report"
+  },
+  "copy": {
+    "message": "Copy"
+  },
+  "copied": {
+    "message": "Copied ✓"
   }
 }

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -47,7 +47,11 @@ hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
 .empty { color: #6e7681; font-size: 12px; padding: 8px 0; }
 
 .card { background: #161b22; border: 1px solid #21262d; border-radius: 8px; padding: 12px; margin-bottom: 10px; }
-.card h3 { margin: 0 0 8px; font-size: 12px; }
+.card h3 { margin: 0; font-size: 12px; }
+.card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin: 0 0 8px; }
+.copy-btn { width: auto; margin: 0; padding: 3px 8px; font-size: 10px; font-weight: 600; border-radius: 4px; border: 1px solid #30363d; background: none; color: #8b949e; cursor: pointer; flex-shrink: 0; }
+.copy-btn:hover { border-color: #484f58; color: #fff; }
+.copy-btn:disabled { color: #3fb950; border-color: #3fb950; cursor: default; }
 .row { display: flex; justify-content: space-between; gap: 8px; padding: 2px 0; font-size: 11px; }
 .row .k { color: #8b949e; flex-shrink: 0; }
 .row .v { color: #e6edf3; text-align: right; font-family: ui-monospace, monospace; word-break: break-word; }
@@ -153,6 +157,21 @@ hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
 
   .empty {
     color: #656d76;
+  }
+
+  .copy-btn {
+    border-color: #d0d7de;
+    color: #424a53;
+  }
+
+  .copy-btn:hover {
+    border-color: #b1bac4;
+    color: #24292f;
+  }
+
+  .copy-btn:disabled {
+    color: #1a7f37;
+    border-color: #1a7f37;
   }
 
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -204,7 +204,10 @@ function moduleCard(name, obj) {
   if (!rows.length) return null;
 
   const card = mk("div", "card");
-  card.appendChild(mk("h3", null, TITLES[name] || name));
+  const head = mk("div", "card-head");
+  head.appendChild(mk("h3", null, TITLES[name] || name));
+  head.appendChild(copyButton(TITLES[name] || name, rows));
+  card.appendChild(head);
   rows.forEach(([k, v]) => {
     const row = mk("div", "row");
     row.appendChild(mk("span", "k", k));
@@ -215,4 +218,18 @@ function moduleCard(name, obj) {
     card.appendChild(row);
   });
   return card;
+}
+
+function copyButton(title, rows) {
+  const btn = mk("button", "copy-btn", t("copy", "Copy"));
+  btn.type = "button";
+  btn.addEventListener("click", () => {
+    const lines = rows.map(([k, v]) => `${k}: ${Array.isArray(v) ? v.join(", ") : v}`);
+    navigator.clipboard.writeText([title, ...lines].join("\n")).then(() => {
+      btn.textContent = t("copied", "Copied ✓");
+      btn.disabled = true;
+      setTimeout(() => { btn.textContent = t("copy", "Copy"); btn.disabled = false; }, 1200);
+    });
+  });
+  return btn;
 }


### PR DESCRIPTION
## Summary
Adds a Copy button to each module result card in the extension popup, so users can copy a card's findings without manually selecting text.

## Changes
- `extension/popup.js`: new `copyButton()` helper wired into `moduleCard()`; copies rows as plain text via `navigator.clipboard.writeText`, shows "Copied ✓" briefly
- `extension/popup.css`: `.card-head` / `.copy-btn` styles (dark + light mode)
- `extension/_locales/en/messages.json`: `copy` / `copied` strings

## Type of change
- [x] New feature

## Testing
- [x] I have tested these changes locally
- [ ] No existing automated test coverage for the extension (pytest suite only covers `modules/`)

Fixes #241