### PR TITLE
Show recent scanned targets as clickable chips in extension popup

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -12,6 +12,10 @@ button { width: 100%; margin-top: 10px; padding: 9px; font-size: 13px; font-weig
 .primary:hover { background: #3b7de0; }
 .ghost { background: none; border: 1px solid #30363d; color: #adbac7; font-weight: 500; margin-top: 8px; }
 .ghost:hover { border-color: #484f58; }
+.recent-targets { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 0; }
+.chip { width: auto; margin: 0; padding: 4px 9px; font-size: 11px; font-weight: 500; border-radius: 999px; border: 1px solid #30363d; background: #161b22; color: #adbac7; cursor: pointer; font-family: ui-monospace, monospace; }
+.chip:hover { border-color: #4f8ef7; color: #fff; }
+
 hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
 .note { font-size: 11px; color: #6e7681; margin: 6px 0 0; }
 .ok { font-size: 11px; color: #3fb950; margin-top: 6px; min-height: 14px; }
@@ -153,6 +157,17 @@ hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
 
   .empty {
     color: #656d76;
+  }
+
+  .chip {
+    background: #f6f8fa;
+    border-color: #d0d7de;
+    color: #424a53;
+  }
+
+  .chip:hover {
+    border-color: #4f8ef7;
+    color: #24292f;
   }
 
 }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -13,6 +13,7 @@
 
       <label for="target" data-i18n="targetLabel">Target</label>
       <input id="target" data-i18n-ph="targetPlaceholder" placeholder="domain, IP, email, phone, username" />
+      <div id="recentTargets" class="recent-targets" hidden></div>
       <button id="scan" class="primary" data-i18n="scanButton">Scan</button>
 
       <hr />

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -28,6 +28,40 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const formView = $("formView"), scanView = $("scanView");
 const urlInput = $("url"), keyInput = $("apikey"), targetInput = $("target"), saved = $("saved");
 const bar = $("bar"), barWrap = $("barWrap"), logEl = $("log"), statusEl = $("status");
+const recentEl = $("recentTargets");
+
+const RECENT_KEY = "recentTargets";
+const MAX_RECENT = 5;
+
+function renderRecentTargets(list) {
+  clear(recentEl);
+  recentEl.hidden = !list.length;
+  list.forEach((target) => {
+    const chip = mk("button", "chip", target);
+    chip.type = "button";
+    chip.addEventListener("click", () => {
+      targetInput.value = target;
+      targetInput.focus();
+    });
+    recentEl.appendChild(chip);
+  });
+}
+
+function loadRecentTargets() {
+  chrome.storage.local.get({ [RECENT_KEY]: [] }, (data) => renderRecentTargets(data[RECENT_KEY]));
+}
+
+function saveRecentTarget(target) {
+  chrome.storage.local.get({ [RECENT_KEY]: [] }, (data) => {
+    const list = data[RECENT_KEY].filter((t) => t.toLowerCase() !== target.toLowerCase());
+    list.unshift(target);
+    const trimmed = list.slice(0, MAX_RECENT);
+    chrome.storage.local.set({ [RECENT_KEY]: trimmed });
+    renderRecentTargets(trimmed);
+  });
+}
+
+loadRecentTargets();
 
 function showForm() { formView.hidden = false; scanView.hidden = true; }
 function showScan() { formView.hidden = true; scanView.hidden = false; }
@@ -65,6 +99,7 @@ function runScan() {
   const server = baseUrl(urlInput.value);
   const apiKey = keyInput.value.trim();
   chrome.storage.sync.set({ instanceUrl: urlInput.value.trim(), apiKey });
+  saveRecentTarget(target);
   start(target, server, apiKey);
 }
 $("scan").addEventListener("click", runScan);


### PR DESCRIPTION
## Summary
Persists the last ~5 scanned targets and shows them as clickable chips below the target input in the extension popup, so users don't have to retype recent targets.

## Changes
- `extension/popup.js`: `loadRecentTargets()` / `saveRecentTarget()` / `renderRecentTargets()` backed by `chrome.storage.local`; `runScan()` now records the target on scan start. Clicking a chip fills the input (does not auto-start a scan).
- `extension/popup.html`: new `#recentTargets` container below the target input
- `extension/popup.css`: `.recent-targets` / `.chip` styles (dark + light mode)

## Type of change
- [x] New feature

## Testing
- [x] I have tested these changes locally
- [ ] No existing automated test coverage for the extension (pytest suite only covers `modules/`)

Fixes #240