### PR TITLE
Add a clear action for recent extension targets

### DIFF
--- a/extension/_locales/de/messages.json
+++ b/extension/_locales/de/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "Gespeichert"
   },
+  "clearRecent": {
+    "message": "Letzte Ziele löschen"
+  },
   "apiKeyLabel": {
     "message": "API-Schlüssel (optional)"
   },

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "Saved"
   },
+  "clearRecent": {
+    "message": "Clear recent targets"
+  },
   "apiKeyLabel": {
     "message": "API key (optional)"
   },

--- a/extension/_locales/es/messages.json
+++ b/extension/_locales/es/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "Guardado"
   },
+  "clearRecent": {
+    "message": "Borrar objetivos recientes"
+  },
   "apiKeyLabel": {
     "message": "Clave API (opcional)"
   },

--- a/extension/_locales/fr/messages.json
+++ b/extension/_locales/fr/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "Enregistré"
   },
+  "clearRecent": {
+    "message": "Effacer les cibles récentes"
+  },
   "apiKeyLabel": {
     "message": "Clé API (facultatif)"
   },

--- a/extension/_locales/it/messages.json
+++ b/extension/_locales/it/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "Salvato"
   },
+  "clearRecent": {
+    "message": "Cancella destinazioni recenti"
+  },
   "apiKeyLabel": {
     "message": "Chiave API (opzionale)"
   },

--- a/extension/_locales/pl/messages.json
+++ b/extension/_locales/pl/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "Zapisano"
   },
+  "clearRecent": {
+    "message": "Wyczyść ostatnie cele"
+  },
   "apiKeyLabel": {
     "message": "Klucz API (opcjonalnie)"
   },

--- a/extension/_locales/pt/messages.json
+++ b/extension/_locales/pt/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "Salvo"
   },
+  "clearRecent": {
+    "message": "Limpar alvos recentes"
+  },
   "apiKeyLabel": {
     "message": "Chave de API (opcional)"
   },

--- a/extension/_locales/ru/messages.json
+++ b/extension/_locales/ru/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "Сохранено"
   },
+  "clearRecent": {
+    "message": "Очистить недавние цели"
+  },
   "apiKeyLabel": {
     "message": "API-ключ (необязательно)"
   },

--- a/extension/_locales/zh_CN/messages.json
+++ b/extension/_locales/zh_CN/messages.json
@@ -29,6 +29,9 @@
   "savedOk": {
     "message": "已保存"
   },
+  "clearRecent": {
+    "message": "清除最近目标"
+  },
   "apiKeyLabel": {
     "message": "API 密钥（可选）"
   },

--- a/extension/popup.css
+++ b/extension/popup.css
@@ -15,6 +15,8 @@ button { width: 100%; margin-top: 10px; padding: 9px; font-size: 13px; font-weig
 .recent-targets { display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0 0; }
 .chip { width: auto; margin: 0; padding: 4px 9px; font-size: 11px; font-weight: 500; border-radius: 999px; border: 1px solid #30363d; background: #161b22; color: #adbac7; cursor: pointer; font-family: ui-monospace, monospace; }
 .chip:hover { border-color: #4f8ef7; color: #fff; }
+.clear-recent { width: auto; margin: 0 0 0 2px; padding: 4px 5px; background: none; color: #8b949e; font-size: 11px; font-weight: 500; }
+.clear-recent:hover { color: #fff; }
 
 hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
 .note { font-size: 11px; color: #6e7681; margin: 6px 0 0; }
@@ -186,6 +188,14 @@ hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
 
   .chip:hover {
     border-color: #4f8ef7;
+    color: #24292f;
+  }
+
+  .clear-recent {
+    color: #656d76;
+  }
+
+  .clear-recent:hover {
     color: #24292f;
   }
 }

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -45,6 +45,18 @@ function renderRecentTargets(list) {
     });
     recentEl.appendChild(chip);
   });
+  if (list.length) {
+    const clearButton = mk("button", "clear-recent", t("clearRecent", "Clear recent targets"));
+    clearButton.type = "button";
+    clearButton.addEventListener("click", () => {
+      chrome.storage.local.set({ [RECENT_KEY]: [] }, () => {
+        if (chrome.runtime.lastError) return;
+        renderRecentTargets([]);
+        targetInput.focus();
+      });
+    });
+    recentEl.appendChild(clearButton);
+  }
 }
 
 function loadRecentTargets() {


### PR DESCRIPTION
## Summary

Add a localized **Clear recent targets** action to the extension popup. The action is shown only when history exists and removes the saved list without affecting server or API-key settings.

Closes #268.

## Changes

- Render and style the clear action alongside recent-target chips in dark and light themes.
- Persist an empty recent-target list, keep the current UI when storage reports an error, and return keyboard focus to the target input after success.
- Add the new label to all nine existing extension locales.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing

- [x] I have tested these changes locally
- [ ] I have added/updated repository tests as needed (the popup has no existing JavaScript test harness)
- [x] `node --check extension/popup.js`
- [x] Fake-DOM/storage harness covering render, localization, success, focus restoration, and storage failure
- [x] All locale catalogs parse and contain `clearRecent`
- [x] `python -m pytest -q` (239 passed; 18 existing deprecation warnings)
- [x] `git diff --check`

## Screenshots

Not included; the behavior and both storage outcomes were exercised with the popup harness.

Disclosure: OpenAI Codex assisted with implementation and tests. The exact revised patch was independently reviewed by Google Antigravity and validated locally; no AI model is credited as a legal author.
