### PR TITLE
Test : Test for graph export

### DIFF
--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -1,0 +1,4 @@
+from modules.graph_export import (
+    _hex_to_rgb,
+    _nodes_edges
+    )

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -1,4 +1,107 @@
 from modules.graph_export import (
     _hex_to_rgb,
-    _nodes_edges
-    )
+    to_graphml,
+    to_gexf
+)
+import xml.etree.ElementTree as ET
+class TestHexToRgb:
+    def test_hex_to_rgb_with_non_string_input(self):
+        assert _hex_to_rgb(123) == (150,150,150)
+        assert _hex_to_rgb('A') == (150,150,150)
+        assert _hex_to_rgb([1,2,3]) == (150,150,150)
+        assert _hex_to_rgb({1:2}) == (150,150,150)
+        assert _hex_to_rgb(True) == (150,150,150)
+    def test_hex_to_rgb_with_wrong_hex_value(self):
+        assert _hex_to_rgb("123abc") == (150,150,150)
+        assert _hex_to_rgb("#000ffff") == (150,150,150)
+        assert _hex_to_rgb("#zzzzzz") == (150,150,150)
+    def test_hex_to_rgb_with_right_value(self):
+        assert _hex_to_rgb("#000000") == (0,0,0)
+class TestGraphml:
+    def test_to_graphml_empyt_graph(self):
+        ns = "http://graphml.graphdrawing.org/xmlns"
+        root = ET.Element("graphml", {"xmlns": ns})
+        g = ET.SubElement(root, "graph", {"edgedefault": "directed"})
+        assert to_graphml({}) == '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
+    def test_to_graphml_graph(self):
+        graph = {
+            "nodes": [
+                {
+                    "id": "1",
+                    "label": "Node A",
+                    "type": "function",
+                    "color": "#FF0000",
+                },
+                {
+                    "id": "2",
+                    "label": "Node B",
+                    "type": "class",
+                    "color": "#00FF00",
+                },
+            ],
+            "edges": [
+                {
+                    "from": "1",
+                    "to": "2",
+                    "label": "calls",
+                }
+            ],
+        }
+        result = to_graphml(graph)
+        assert '<?xml version="1.0" encoding="UTF-8"?>' in result
+        assert '<node id="1">' in result
+        assert '<node id="2">' in result
+        assert "Node A" in result
+        assert "Node B" in result
+    def test_to_graphml_graph_with_no_label(self):
+        graph = {
+            "nodes": [
+                {
+                    "id": "1",
+                    "type": "function",
+                    "color": "#FF0000",
+                }
+            ],
+            "edges": [],
+        }
+        result = to_graphml(graph)
+        root = ET.fromstring(result)
+
+        node = root.find(".//{http://graphml.graphdrawing.org/xmlns}node")
+        assert node is not None
+        assert node.get("id") == "1"
+
+        data = {
+            element.get("key"): element.text
+            for element in node
+        }
+
+        assert data["label"] in (None, "")
+        assert data["type"] == "function"
+        assert data["color"] == "#FF0000"
+    def test_to_graphml_node_without_type_or_color():
+        graph = {
+            "nodes": [
+                {
+                    "id": "1",
+                }
+            ],
+            "edges": [],
+        }
+
+        result = to_graphml(graph)
+
+        root = ET.fromstring(result)
+
+        node = root.find(".//{http://graphml.graphdrawing.org/xmlns}node")
+        assert node is not None
+
+        data = {
+            element.get("key"): element.text
+            for element in node
+        }
+
+        assert data["label"] in (None, "")
+        assert data["type"] in (None, "")
+        assert data["color"] in (None, "")
+# class TestGexf:

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -12,7 +12,6 @@ class TestHexToRgb:
         assert _hex_to_rgb({1:2}) == (150,150,150)
         assert _hex_to_rgb(True) == (150,150,150)
     def test_hex_to_rgb_with_wrong_hex_value(self):
-        assert _hex_to_rgb("123abc") == (150,150,150)
         assert _hex_to_rgb("#000ffff") == (150,150,150)
         assert _hex_to_rgb("#zzzzzz") == (150,150,150)
     def test_hex_to_rgb_with_right_value(self):
@@ -21,6 +20,15 @@ class TestGraphml:
     def test_to_graphml_empyt_graph(self):
         ns = "http://graphml.graphdrawing.org/xmlns"
         root = ET.Element("graphml", {"xmlns": ns})
+        for key_id, target, name in (
+        ("label", "node", "label"),
+        ("type", "node", "type"),
+        ("color", "node", "color"),
+        ("elabel", "edge", "label"),
+        ):
+            ET.SubElement(root, "key", {
+                "id": key_id, "for": target, "attr.name": name, "attr.type": "string",
+            })
         g = ET.SubElement(root, "graph", {"edgedefault": "directed"})
         assert to_graphml({}) == '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
     def test_to_graphml_graph(self):
@@ -79,7 +87,7 @@ class TestGraphml:
         assert data["label"] in (None, "")
         assert data["type"] == "function"
         assert data["color"] == "#FF0000"
-    def test_to_graphml_node_without_type_or_color():
+    def test_to_graphml_node_without_type_or_color(self):
         graph = {
             "nodes": [
                 {
@@ -104,4 +112,93 @@ class TestGraphml:
         assert data["label"] in (None, "")
         assert data["type"] in (None, "")
         assert data["color"] in (None, "")
-# class TestGexf:
+class TestGexf:
+    def test_to_gexf_empty_graph(self):
+        result = to_gexf({})
+
+        root = ET.fromstring(result)
+
+        ns = "http://gexf.net/1.3"
+
+        assert root.tag == f"{{{ns}}}gexf"
+
+        graph = root.find(f"{{{ns}}}graph")
+        assert graph is not None
+        assert graph.get("mode") == "static"
+        assert graph.get("defaultedgetype") == "directed"
+
+        nodes = graph.find(f"{{{ns}}}nodes")
+        edges = graph.find(f"{{{ns}}}edges")
+
+        assert nodes is not None
+        assert edges is not None
+        assert list(nodes) == []
+        assert list(edges) == []
+    def test_to_gexf_graph(self):
+        graph = {
+            "nodes": [
+                {
+                    "id": "1",
+                    "label": "Node A",
+                    "type": "function",
+                    "color": "#FF0000",
+                },
+                {
+                    "id": "2",
+                    "label": "Node B",
+                    "type": "class",
+                    "color": "#00FF00",
+                },
+            ],
+            "edges": [
+                {
+                    "from": "1",
+                    "to": "2",
+                    "label": "calls",
+                }
+            ],
+        }
+
+        result = to_gexf(graph)
+        root = ET.fromstring(result)
+
+        ns = "http://gexf.net/1.3"
+
+        graph_el = root.find(f"{{{ns}}}graph")
+        assert graph_el is not None
+
+        nodes = graph_el.find(f"{{{ns}}}nodes")
+        edges = graph_el.find(f"{{{ns}}}edges")
+
+        assert nodes is not None
+        assert edges is not None
+
+        assert len(nodes) == 2
+        assert len(edges) == 1
+    def test_to_gexf_color(self):
+        graph = {
+            "nodes": [
+                {
+                    "id": "1",
+                    "label": "Node A",
+                    "type": "function",
+                    "color": "#FF0000",
+                }
+            ],
+            "edges": [],
+        }
+
+        result = to_gexf(graph)
+        root = ET.fromstring(result)
+
+        ns = "http://gexf.net/1.3"
+
+        node = root.find(f".//{{{ns}}}node")
+        assert node is not None
+
+        color = node.find("{http://gexf.net/1.3/viz}color")
+        assert color is not None
+
+        assert color.get("r") == "255"
+        assert color.get("g") == "0"
+        assert color.get("b") == "0"

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -4,6 +4,35 @@ from modules.graph_export import (
     to_gexf
 )
 import xml.etree.ElementTree as ET
+import pytest
+import copy
+
+@pytest.fixture
+def graph():
+    return {
+        "nodes": [
+            {
+                "id": "1",
+                "label": "Node A",
+                "type": "function",
+                "color": "#FF0000",
+            },
+            {
+                "id": "2",
+                "label": "Node B",
+                "type": "class",
+                "color": "#00FF00",
+            },
+        ],
+        "edges": [
+            {
+                "from": "1",
+                "to": "2",
+                "label": "calls",
+            }
+        ],
+    }
+
 class TestHexToRgb:
     def test_hex_to_rgb_with_non_string_input(self):
         assert _hex_to_rgb(123) == (150,150,150)
@@ -16,63 +45,74 @@ class TestHexToRgb:
         assert _hex_to_rgb("#zzzzzz") == (150,150,150)
     def test_hex_to_rgb_with_right_value(self):
         assert _hex_to_rgb("#000000") == (0,0,0)
+
 class TestGraphml:
-    def test_to_graphml_empyt_graph(self):
+    def test_to_graphml_empty_graph(self):
+        result = to_graphml({})
+
+        root = ET.fromstring(result)
+
         ns = "http://graphml.graphdrawing.org/xmlns"
-        root = ET.Element("graphml", {"xmlns": ns})
-        for key_id, target, name in (
-        ("label", "node", "label"),
-        ("type", "node", "type"),
-        ("color", "node", "color"),
-        ("elabel", "edge", "label"),
-        ):
-            ET.SubElement(root, "key", {
-                "id": key_id, "for": target, "attr.name": name, "attr.type": "string",
-            })
-        g = ET.SubElement(root, "graph", {"edgedefault": "directed"})
-        assert to_graphml({}) == '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
-    def test_to_graphml_graph(self):
-        graph = {
-            "nodes": [
-                {
-                    "id": "1",
-                    "label": "Node A",
-                    "type": "function",
-                    "color": "#FF0000",
-                },
-                {
-                    "id": "2",
-                    "label": "Node B",
-                    "type": "class",
-                    "color": "#00FF00",
-                },
-            ],
-            "edges": [
-                {
-                    "from": "1",
-                    "to": "2",
-                    "label": "calls",
-                }
-            ],
+
+        assert root.tag == f"{{{ns}}}graphml"
+
+        graph = root.find(f"{{{ns}}}graph")
+        assert graph is not None
+        assert graph.get("edgedefault") == "directed"
+
+        nodes = graph.findall(f"{{{ns}}}node")
+        edges = graph.findall(f"{{{ns}}}edge")
+
+        assert nodes == []
+        assert edges == []
+
+        keys = root.findall(f"{{{ns}}}key")
+
+        assert len(keys) == 4
+
+        key_data = {
+            key.get("id"): {
+                "for": key.get("for"),
+                "attr.name": key.get("attr.name"),
+                "attr.type": key.get("attr.type"),
+            }
+            for key in keys
         }
+
+        assert key_data == {
+            "label": {
+                "for": "node",
+                "attr.name": "label",
+                "attr.type": "string",
+            },
+            "type": {
+                "for": "node",
+                "attr.name": "type",
+                "attr.type": "string",
+            },
+            "color": {
+                "for": "node",
+                "attr.name": "color",
+                "attr.type": "string",
+            },
+            "elabel": {
+                "for": "edge",
+                "attr.name": "label",
+                "attr.type": "string",
+            },
+        }
+    def test_to_graphml_graph(self,graph):
         result = to_graphml(graph)
         assert '<?xml version="1.0" encoding="UTF-8"?>' in result
         assert '<node id="1">' in result
         assert '<node id="2">' in result
         assert "Node A" in result
         assert "Node B" in result
-    def test_to_graphml_graph_with_no_label(self):
-        graph = {
-            "nodes": [
-                {
-                    "id": "1",
-                    "type": "function",
-                    "color": "#FF0000",
-                }
-            ],
-            "edges": [],
-        }
-        result = to_graphml(graph)
+    def test_to_graphml_graph_with_no_label(self,graph):
+        test_graph = copy.deepcopy(graph)
+        for node in test_graph["nodes"]:
+            node.pop("label")
+        result = to_graphml(test_graph)
         root = ET.fromstring(result)
 
         node = root.find(".//{http://graphml.graphdrawing.org/xmlns}node")
@@ -87,17 +127,12 @@ class TestGraphml:
         assert data["label"] in (None, "")
         assert data["type"] == "function"
         assert data["color"] == "#FF0000"
-    def test_to_graphml_node_without_type_or_color(self):
-        graph = {
-            "nodes": [
-                {
-                    "id": "1",
-                }
-            ],
-            "edges": [],
-        }
-
-        result = to_graphml(graph)
+    def test_to_graphml_node_without_type_or_color(self,graph):
+        test_graph = copy.deepcopy(graph)
+        for node in test_graph["nodes"]:
+            node.pop("type")
+            node.pop("color")
+        result = to_graphml(test_graph)
 
         root = ET.fromstring(result)
 
@@ -108,8 +143,7 @@ class TestGraphml:
             element.get("key"): element.text
             for element in node
         }
-
-        assert data["label"] in (None, "")
+        
         assert data["type"] in (None, "")
         assert data["color"] in (None, "")
 class TestGexf:
@@ -134,31 +168,7 @@ class TestGexf:
         assert edges is not None
         assert list(nodes) == []
         assert list(edges) == []
-    def test_to_gexf_graph(self):
-        graph = {
-            "nodes": [
-                {
-                    "id": "1",
-                    "label": "Node A",
-                    "type": "function",
-                    "color": "#FF0000",
-                },
-                {
-                    "id": "2",
-                    "label": "Node B",
-                    "type": "class",
-                    "color": "#00FF00",
-                },
-            ],
-            "edges": [
-                {
-                    "from": "1",
-                    "to": "2",
-                    "label": "calls",
-                }
-            ],
-        }
-
+    def test_to_gexf_graph(self,graph):
         result = to_gexf(graph)
         root = ET.fromstring(result)
 
@@ -175,19 +185,7 @@ class TestGexf:
 
         assert len(nodes) == 2
         assert len(edges) == 1
-    def test_to_gexf_color(self):
-        graph = {
-            "nodes": [
-                {
-                    "id": "1",
-                    "label": "Node A",
-                    "type": "function",
-                    "color": "#FF0000",
-                }
-            ],
-            "edges": [],
-        }
-
+    def test_to_gexf_color(self,graph):
         result = to_gexf(graph)
         root = ET.fromstring(result)
 


### PR DESCRIPTION
## Summary
<!-- Describe your changes briefly -->
Add tests for the graph export module. closes #154 
## Changes
<!-- List specific changes -->
- Added unit tests for the `_hex_to_rgb` helper
- Added tests for GraphML export with empty and populated graphs
- Added tests for GraphML nodes with missing labels, types, and colors
- Added tests for GEXF export with empty and populated graphs
- Added coverage for GEXF node colors and edge handling

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [x] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
