### PR TITLE
Fix username handling in Blackbird exports and lookups

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -209,11 +209,14 @@ async def run_scan(
             _log("Running blackbird ...")
             from modules.blackbird import Blackbird
             bb = Blackbird(timeout=10, max_concurrent=25)
-            await _invoke(bb.search, target)
-            results["blackbird"] = [
-                {"site": r.site, "url": r.url, "status": r.status, "response_time": r.response_time}
-                for r in bb.results
-            ]
+            outcome = await _invoke(bb.search, target)
+            if isinstance(outcome, dict) and outcome.get("error"):
+                results["blackbird"] = outcome
+            else:
+                results["blackbird"] = [
+                    {"site": r.site, "url": r.url, "status": r.status, "response_time": r.response_time}
+                    for r in bb.results
+                ]
 
         if want("maigret"):
             _log("Running maigret ...")

--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -702,11 +702,12 @@ export function ScanResults({ scan, onHome }: Props) {
         r.cert_transparency.subdomains.forEach(s => lines.push(`- ${s}`));
         lines.push('');
       }
-      if (r.blackbird?.some(b => b.status === 'found')) {
+      const found = Array.isArray(r.blackbird) ? r.blackbird.filter(b => b.status === 'found') : [];
+      if (found.length) {
         lines.push('## Accounts Found');
         lines.push('| Platform | URL |');
         lines.push('|----------|-----|');
-        r.blackbird.filter(b => b.status === 'found').forEach(b => lines.push(`| ${b.site} | ${b.url} |`));
+        found.forEach(b => lines.push(`| ${b.site} | ${b.url} |`));
         lines.push('');
       }
       const md = lines.join('\n');
@@ -779,6 +780,8 @@ export function ScanResults({ scan, onHome }: Props) {
 
   const [accountFilter, setAccountFilter] = useState('');
 
+  const accounts = Array.isArray(r.blackbird) ? r.blackbird : [];
+
   const skippedIpProviders = [
     { name: 'Shodan', mod: r.shodan, key: 'SHODAN_API_KEY' },
     { name: 'VirusTotal', mod: r.virustotal, key: 'VIRUSTOTAL_API_KEY' },
@@ -792,7 +795,7 @@ export function ScanResults({ scan, onHome }: Props) {
     if (t.id === 'whois') return r.whois && !r.whois.error;
     if (t.id === 'dns') return r.dns?.records && Object.keys(r.dns.records).length > 0;
     if (t.id === 'subdomains') return r.cert_transparency?.subdomains?.length;
-    if (t.id === 'accounts') return r.blackbird?.some(b => b.status === 'found');
+    if (t.id === 'accounts') return accounts.some(b => b.status === 'found');
     if (t.id === 'github') return r.github && modStatus(r.github) === 'ok';
     if (t.id === 'threats') return [r.virustotal, r.abuseipdb, r.shodan].some(m => m && modStatus(m) !== 'error');
     if (t.id === 'censys') return r.censys && modStatus(r.censys) === 'ok';
@@ -1055,7 +1058,7 @@ export function ScanResults({ scan, onHome }: Props) {
               <thead><tr className="text-left text-text-3 text-[10px] uppercase tracking-wider border-b border-border-1">
                 <th className="pb-2">Platform</th><th className="pb-2">URL</th><th className="pb-2 text-right">Time</th>
               </tr></thead>
-              <tbody>{r.blackbird?.filter(b => b.status === 'found' && (!accountFilter || b.site.toLowerCase().includes(accountFilter.toLowerCase()))).map(b => (
+              <tbody>{accounts.filter(b => b.status === 'found' && (!accountFilter || b.site.toLowerCase().includes(accountFilter.toLowerCase()))).map(b => (
                 <tr key={b.site} className="border-b border-border-1 last:border-0">
                   <td className="py-2 font-medium text-text-1">{b.site}</td>
                   <td className="py-2">
@@ -1069,7 +1072,7 @@ export function ScanResults({ scan, onHome }: Props) {
               ))}</tbody>
             </table>
             </div>
-            {(r.blackbird?.filter(b => b.status === 'found' && (!accountFilter || b.site.toLowerCase().includes(accountFilter.toLowerCase())))?.length === 0) && (
+            {(accounts.filter(b => b.status === 'found' && (!accountFilter || b.site.toLowerCase().includes(accountFilter.toLowerCase()))).length === 0) && (
               <div className="flex flex-col items-center justify-center py-10 text-center">
                 <User size={24} className="text-text-3 opacity-40 mb-2" />
                 <div className="text-text-3 text-sm">

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -208,12 +208,16 @@ export interface GravatarData extends ModuleStatusFields {
   error?: string;
 }
 
+export interface BlackbirdFailure extends ModuleStatusFields {
+  error?: string;
+}
+
 export interface ScanResults {
   whois?: WhoisData;
   dns?: DnsRecord;
   geoip?: GeoipData;
   cert_transparency?: CertTransparencyData;
-  blackbird?: BlackbirdResult[];
+  blackbird?: BlackbirdResult[] | BlackbirdFailure;
   virustotal?: VirusTotalData;
   abuseipdb?: AbuseIPDBData;
   shodan?: ShodanData;

--- a/modules/blackbird.py
+++ b/modules/blackbird.py
@@ -3,13 +3,19 @@ import aiohttp
 import json
 import csv
 import os
+import re
 import html as _html
 from datetime import datetime
 from typing import Dict, List, Any, Optional
 from dataclasses import dataclass
+from urllib.parse import quote
 import sys
 sys.path.append('..')
 from config import OUTPUT_DIR, Colors
+
+
+def _safe_username(username: str) -> str:
+    return re.sub(r'[^A-Za-z0-9_.-]', '_', username or '')[:64] or "target"
 
 
 @dataclass
@@ -83,7 +89,7 @@ class Blackbird:
     async def check_site(self, session: aiohttp.ClientSession, username: str,
                          site: str, config: tuple) -> SiteResult:
         url_template, error_type, error_indicator = config
-        url = url_template.format(username)
+        url = url_template.format(quote(username, safe=""))
 
         start_time = asyncio.get_event_loop().time()
 
@@ -143,7 +149,7 @@ class Blackbird:
 
     def export_json(self, username: str, filepath: str = None) -> str:
         if filepath is None:
-            filepath = os.path.join(OUTPUT_DIR, f"blackbird_{username}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json")
+            filepath = os.path.join(OUTPUT_DIR, f"blackbird_{_safe_username(username)}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json")
 
         data = {
             "username": username,
@@ -169,7 +175,7 @@ class Blackbird:
 
     def export_csv(self, username: str, filepath: str = None) -> str:
         if filepath is None:
-            filepath = os.path.join(OUTPUT_DIR, f"blackbird_{username}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv")
+            filepath = os.path.join(OUTPUT_DIR, f"blackbird_{_safe_username(username)}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.csv")
 
         with open(filepath, 'w', newline='', encoding='utf-8') as f:
             writer = csv.writer(f)
@@ -181,7 +187,7 @@ class Blackbird:
 
     def export_html(self, username: str, filepath: str = None) -> str:
         if filepath is None:
-            filepath = os.path.join(OUTPUT_DIR, f"blackbird_{username}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.html")
+            filepath = os.path.join(OUTPUT_DIR, f"blackbird_{_safe_username(username)}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.html")
 
         found = self.get_found()
 
@@ -235,7 +241,7 @@ class Blackbird:
 
     def export_txt(self, username: str, filepath: str = None) -> str:
         if filepath is None:
-            filepath = os.path.join(OUTPUT_DIR, f"blackbird_{username}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt")
+            filepath = os.path.join(OUTPUT_DIR, f"blackbird_{_safe_username(username)}_{datetime.now().strftime('%Y%m%d_%H%M%S')}.txt")
 
         found = self.get_found()
 

--- a/tests/test_modules_extended.py
+++ b/tests/test_modules_extended.py
@@ -571,6 +571,37 @@ class TestBlackbird:
         assert data["total_found"] == 1
         assert data["total_checked"] == 2
 
+    @pytest.mark.parametrize("username", [
+        "user?name",
+        'user"name',
+        "user:name",
+        "../../../pwned",
+        "a" * 300,
+        "",
+    ])
+    def test_export_json_keeps_hostile_usernames_inside_output_dir(self, username):
+        from config import OUTPUT_DIR
+        from modules.blackbird import Blackbird, SiteResult
+        bb = Blackbird()
+        bb.results = [SiteResult("GitHub", "https://github.com/x", "found", 200, 0.5)]
+        path = bb.export_json(username)
+        try:
+            assert os.path.exists(path)
+            assert os.path.abspath(path).startswith(os.path.abspath(OUTPUT_DIR))
+        finally:
+            os.remove(path)
+
+    @pytest.mark.parametrize("username", ["evil.com/#", "evil.com?", "../../../etc", "a@evil.com"])
+    def test_check_site_urls_stay_on_the_expected_host(self, username):
+        from urllib.parse import quote
+        from yarl import URL
+        from modules.blackbird import Blackbird
+        for template, _type, _indicator in Blackbird.SITES.values():
+            base_host = URL(template.format("x")).host
+            suffix = base_host[1:] if base_host.startswith("x") else base_host
+            host = URL(template.format(quote(username, safe=""))).host
+            assert host.endswith(suffix)
+
     def test_export_csv(self, tmp_path):
         from modules.blackbird import Blackbird, SiteResult
         bb = Blackbird()

--- a/web/app.py
+++ b/web/app.py
@@ -618,11 +618,14 @@ async def _execute_scan(scan_id: str, target: str, scan_type: str, modules: list
             if want("blackbird"):
                 from modules.blackbird import Blackbird
                 bb = Blackbird(timeout=10, max_concurrent=25)
-                await _run_module(scan_id, "blackbird", bb.search, target)
-                results["blackbird"] = [
-                    {"site": r.site, "url": r.url, "status": r.status, "response_time": r.response_time}
-                    for r in bb.results
-                ]
+                outcome = await _run_module(scan_id, "blackbird", bb.search, target)
+                if isinstance(outcome, dict) and outcome.get("error"):
+                    results["blackbird"] = outcome
+                else:
+                    results["blackbird"] = [
+                        {"site": r.site, "url": r.url, "status": r.status, "response_time": r.response_time}
+                        for r in bb.results
+                    ]
 
             if want("maigret"):
                 from modules.maigret_wrapper import MaigretWrapper


### PR DESCRIPTION
Three problems around username scans, found while chasing the JSON export failure.

**Export paths.** `export_json` and its csv/html/txt siblings built the filename straight from the username. `user?name` raised `OSError` before writing anything, a name past the path limit raised `FileNotFoundError`, and `../../pwned` wrote outside `results/`. `maigret_wrapper` and `report_generator` already sanitise the same way — Blackbird was the one module that didn't.

**Lookup URLs.** `check_site` interpolated the username into the URL template unescaped. The Tumblr entry has the placeholder in the host position, so a username of `evil.com/#` produced `https://evil.com/#.tumblr.com/` and the request went to `evil.com`. `validate_target` only rejects ``[;|`$<>{}]``, so a slash or hash reaches the module untouched. Blind SSRF — the response body isn't returned, only whether the site matched. Needs a valid API key, or `ALLOW_ANON_API=1` as the demo runs.

**Failed searches.** The API and CLI discarded what `_run_module` / `_invoke` returned and read `bb.results`, so a search that raised was stored as `[]`, which reads the same as checking every site and finding nothing.

Blackbird can now be an error object, so the frontend resolves it through `Array.isArray` once instead of calling `.some()` on it — otherwise an error would throw while computing the visible tabs and take the results view down.

Tests: 249 → 259. New cases cover hostile usernames staying inside `results/` and no template letting the host escape its expected domain.

The frontend changes aren't verified locally — I have no Node on this machine, so `tsc`, `eslint` and `build` haven't run. That's what I want the CI job for before this merges.
