### PR TITLE
fix: preserve cancellation in Blackbird site checks

### DIFF
--- a/modules/blackbird.py
+++ b/modules/blackbird.py
@@ -108,14 +108,14 @@ class Blackbird:
                     try:
                         text = await response.text()
                         status = "not_found" if error_indicator.lower() in text.lower() else "found"
-                    except:
+                    except Exception:
                         status = "error"
 
                 return SiteResult(site, url, status, http_code, response_time)
 
         except asyncio.TimeoutError:
             return SiteResult(site, url, "timeout", 0, self.timeout)
-        except Exception as e:
+        except Exception:
             return SiteResult(site, url, "error", 0, 0)
 
     async def search(self, username: str, sites: List[str] = None) -> List[SiteResult]:


### PR DESCRIPTION
Fixes #297

## Summary
Prevent Blackbird response decoding failures from swallowing BaseException subclasses such as task cancellation.

## Changes
- Catch Exception when reading a response body
- Remove an unused exception binding

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed

22 Blackbird-focused tests passed.

## Screenshots
N/A

## Worked on by
- nightcityblade