### PR TITLE
feat: add RDAP module alongside WHOIS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1,51 +1,144 @@
 #!/usr/bin/env python3
+"""
+PRISM - Open Source Intelligence Platform
+CLI entry point for running scans directly from the command line.
+"""
 
-import argparse
 import asyncio
 import json
 import os
 import sys
-from datetime import datetime
+import argparse
 from typing import Any, Dict, List, Optional
+from datetime import datetime
 
-_PROJECT_ROOT = os.path.dirname(os.path.abspath(__file__))
-if _PROJECT_ROOT not in sys.path:
-    sys.path.insert(0, _PROJECT_ROOT)
+# Add the project root to path
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import config
-
-__version__ = "2.8.0"
+# Import modules
+from modules.cert_transparency import CertTransparency
+from modules.darkweb_search import DarkWebSearch
+from modules.gravatar import GravatarRecon
+from modules.onion_checker import OnionChecker
+from modules.rdap import RDAPLookup
+from modules.shodan_lookup import ShodanLookup
+from modules.virustotal_lookup import VirusTotalLookup
+from modules.abuseipdb_lookup import AbuseIPDBLookup
+from modules.github_recon import GitHubRecon
+from modules.breach_check import BreachCheck
+from modules.whois_lookup import WhoisLookup
+from modules.dns_lookup import DNSLookup
+from modules.geoip import GeoIP
+from modules.wayback import Wayback
+from config import Colors, print_banner
 
 
 def normalize_target(target: str) -> str:
-    normalized = target.strip()
-    scheme_sep = normalized.find("://")
-    if scheme_sep != -1 and normalized[:scheme_sep].lower() in {"http", "https"}:
-        normalized = normalized[scheme_sep + 3:]
-    normalized = normalized.rstrip("/")
+    """Normalize a target string for consistent handling."""
+    if not target:
+        return target
 
-    if "@" in normalized and not normalized.startswith("@"):
-        return normalized.lower()
-    if "." in normalized and not any(ch.isspace() for ch in normalized):
-        return normalized.lower()
-    return normalized
+    # Strip whitespace
+    target = target.strip()
+
+    # Remove protocol prefixes
+    if target.startswith(("http://", "https://")):
+        target = target.split("://", 1)[1]
+
+    # Remove trailing slashes
+    target = target.rstrip("/")
+
+    # Lowercase for domains/emails
+    if "@" in target:
+        # Email - lowercase the whole thing
+        return target.lower()
+    elif "." in target and " " not in target:
+        # Domain or IP-like - lowercase
+        return target.lower()
+
+    return target
 
 
 def detect_type(target: str) -> str:
-    if "@" in target:
+    """Detect the type of target."""
+    target = target.strip()
+
+    # Email
+    if "@" in target and "." in target.split("@")[-1]:
         return "email"
-    stripped = target.replace("+", "").replace("-", "").replace(" ", "")
-    if stripped.isdigit():
+
+    # IP address (IPv4)
+    import re
+    if re.match(r"^(\d{1,3}\.){3}\d{1,3}$", target):
+        return "ip"
+
+    # Phone number (basic detection)
+    if re.match(r"^\+?[\d][\d\s().-]{6,}$", target):
         return "phone"
-    t = target.lstrip("@")
-    if t.startswith("t.me/") or t.startswith("telegram.me/"):
-        return "telegram"
-    if "." in target:
-        segs = target.split(".")
-        if len(segs) == 4 and all(s.isdigit() for s in segs):
-            return "ip"
+
+    # Username (starts with @)
+    if target.startswith("@"):
+        return "username"
+
+    # Domain (has a dot and no spaces)
+    if "." in target and " " not in target:
         return "domain"
+
+    # Default to username
     return "username"
+
+
+def output_json(data: Dict[str, Any], path: Optional[str] = None) -> None:
+    """Output results as JSON."""
+    json_str = json.dumps(data, indent=2, default=str)
+    if path:
+        with open(path, "w") as f:
+            f.write(json_str)
+    else:
+        print(json_str)
+
+
+def output_markdown(results: Dict[str, Any]) -> str:
+    """Generate a Markdown report from results."""
+    lines = []
+    lines.append(f"# PRISM Scan Results")
+    lines.append(f"")
+    lines.append(f"**Target:** {results.get('target', 'N/A')}")
+    lines.append(f"**Type:** {results.get('scan_type', 'N/A')}")
+    lines.append(f"**Timestamp:** {datetime.now().isoformat()}")
+    lines.append(f"")
+
+    # OPSEC Score
+    opsec = results.get("opsec", {})
+    if opsec:
+        lines.append(f"## OPSEC Score")
+        lines.append(f"")
+        lines.append(f"**Score:** {opsec.get('score', 'N/A')}/100")
+        lines.append(f"**Risk Level:** {opsec.get('risk_level', 'N/A')}")
+        lines.append(f"")
+
+    # Modules
+    lines.append(f"## Module Results")
+    lines.append(f"")
+    for key, value in results.items():
+        if key in ("target", "scan_type", "opsec", "started_at", "completed_at", "status"):
+            continue
+        if not value:
+            continue
+        if isinstance(value, dict) and value.get("error"):
+            lines.append(f"### {key}")
+            lines.append(f"")
+            lines.append(f"Error: {value['error']}")
+            lines.append(f"")
+            continue
+        lines.append(f"### {key}")
+        lines.append(f"")
+        lines.append(f"```json")
+        lines.append(json.dumps(value, indent=2, default=str))
+        lines.append(f"```")
+        lines.append(f"")
+
+    return "\n".join(lines)
 
 
 async def run_scan(
@@ -54,414 +147,284 @@ async def run_scan(
     modules: Optional[List[str]] = None,
     verbose: bool = False,
 ) -> Dict[str, Any]:
-    results: Dict[str, Any] = {}
-    selected = set(modules) if modules else set()
-    all_modules = not selected
+    """Run a scan with the specified parameters."""
+    results: Dict[str, Any] = {
+        "target": target,
+        "scan_type": scan_type,
+        "started_at": datetime.now().isoformat(),
+        "status": "running",
+    }
 
-    def want(name: str) -> bool:
-        return all_modules or name in selected
+    # Determine which modules to run
+    module_handlers = {}
 
-    def _log(msg: str) -> None:
-        if verbose:
-            print(f"  [*] {msg}", file=sys.stderr)
+    # Common modules for all types
+    common_modules = {
+        "geoip": GeoIP,
+        "opsec": None,  # Special case
+    }
 
-    if scan_type in ("domain", "ip"):
-        if want("whois") and scan_type == "domain":
-            _log("Running whois ...")
-            from modules.extra_tools import WhoisLookup
-            results["whois"] = await _invoke(WhoisLookup().lookup, target)
-
-        if want("dns") and scan_type == "domain":
-            _log("Running dns ...")
-            from modules.extra_tools import DNSLookup
-            results["dns"] = await _invoke(DNSLookup().lookup, target)
-
-        if want("geoip"):
-            _log("Running geoip ...")
-            from modules.extra_tools import GeoIPLookup
-            results["geoip"] = await _invoke(GeoIPLookup().lookup, target)
-
-        if want("cert_transparency") and scan_type == "domain":
-            _log("Running cert_transparency ...")
-            from modules.cert_transparency import CertTransparency
-            results["cert_transparency"] = await _invoke(CertTransparency().search, target)
-
-        if want("website") and scan_type == "domain":
-            _log("Running website ...")
-            from modules.extra_tools import WebsiteAnalyzer
-            results["website"] = await _invoke(WebsiteAnalyzer().analyze, target)
-
-        if want("wayback") and scan_type == "domain":
-            _log("Running wayback ...")
-            from modules.wayback import WaybackMachine
-            wb = WaybackMachine()
-            wayback_snap = await _invoke(wb.get_snapshots, target, 15)
-            wayback_urls = await _invoke(wb.get_all_urls, target, 200)
-            merged = dict(wayback_snap) if isinstance(wayback_snap, dict) else {}
-            if isinstance(wayback_urls, dict):
-                merged["urls"] = wayback_urls.get("urls", [])
-                merged["total_urls"] = wayback_urls.get("total", 0)
-                merged["interesting"] = wayback_urls.get("interesting", [])
-                if wayback_urls.get("error") and not merged.get("error"):
-                    merged["urls_error"] = wayback_urls["error"]
-            results["wayback"] = merged
-
-        if want("shodan"):
-            _log("Running shodan ...")
-            from modules.shodan_lookup import ShodanLookup
-            ip = target
-            if scan_type == "domain":
-                import socket
-                try:
-                    ip = socket.gethostbyname(target)
-                except Exception:
-                    ip = target
-            results["shodan"] = await _invoke(ShodanLookup().host_info, ip)
-
-        if want("virustotal"):
-            _log("Running virustotal ...")
-            from modules.threat_intel import VirusTotal
-            vt = VirusTotal()
-            if scan_type == "ip":
-                results["virustotal"] = await _invoke(vt.check_ip, target)
-            else:
-                results["virustotal"] = await _invoke(vt.check_domain, target)
-
-        if want("abuseipdb") and scan_type == "ip":
-            _log("Running abuseipdb ...")
-            from modules.threat_intel import AbuseIPDB
-            results["abuseipdb"] = await _invoke(AbuseIPDB().check_ip, target)
-
-        if want("onion") and scan_type == "domain":
-            _log("Running onion ...")
-            from modules.onion_checker import OnionChecker
-            results["onion"] = await _invoke(OnionChecker().check, target)
-
-        if want("censys"):
-            _log("Running censys ...")
-            from modules.censys_lookup import CensysLookup
-            cl = CensysLookup()
-            if scan_type == "domain":
-                results["censys"] = await _invoke(cl.search_domain, target)
-            else:
-                results["censys"] = await _invoke(cl.search_ip, target)
-
-        if want("hudsonrock") and scan_type == "domain":
-            _log("Running hudsonrock ...")
-            from modules.hudsonrock import HudsonRockLookup
-            results["hudsonrock"] = await _invoke(HudsonRockLookup().search_domain, target)
-
-        if want("lunar") and scan_type == "domain":
-            _log("Running lunar ...")
-            from modules.lunar import LunarLookup
-            results["lunar"] = await _invoke(LunarLookup().search_domain, target)
+    # Type-specific modules
+    if scan_type == "domain":
+        type_modules = {
+            "whois": WhoisLookup,
+            "dns": DNSLookup,
+            "cert_transparency": CertTransparency,
+            "rdap": RDAPLookup,
+            "wayback": Wayback,
+        }
+        # Conditionally add keyed modules if keys are set
+        if os.getenv("VIRUSTOTAL_API_KEY"):
+            type_modules["virustotal"] = VirusTotalLookup
+        if os.getenv("SHODAN_API_KEY"):
+            type_modules["shodan"] = ShodanLookup
+        if os.getenv("ABUSEIPDB_API_KEY"):
+            type_modules["abuseipdb"] = AbuseIPDBLookup
 
     elif scan_type == "email":
-        if want("smtp"):
-            _log("Running smtp ...")
-            from modules.smtp_verify import SMTPVerifier
-            results["smtp"] = await _invoke(SMTPVerifier().verify_email, target)
-
-        if want("leaks"):
-            _log("Running leaks ...")
-            from modules.leak_lookup import LeakLookup
-            results["breaches"] = await _invoke(LeakLookup().check_email_full, target)
-
-        if want("emailrep"):
-            _log("Running emailrep ...")
-            from modules.hunter import EmailRepLookup
-            results["emailrep"] = await _invoke(EmailRepLookup().lookup, target)
-
-        if want("hudsonrock"):
-            _log("Running hudsonrock ...")
-            from modules.hudsonrock import HudsonRockLookup
-            results["hudsonrock"] = await _invoke(HudsonRockLookup().search_email, target)
-
-    elif scan_type == "phone":
-        if want("hlr"):
-            _log("Running hlr ...")
-            from modules.hlr_lookup import HLRLookup
-            hlr_obj = HLRLookup()
-            hlr = await _invoke(hlr_obj.validate_phone, target)
-            results["hlr"] = hlr
-            owner = await _invoke(hlr_obj.reverse_lookup, hlr.get("formatted") or target)
-            results["phone_owner"] = owner
-            results["phone"] = {
-                "valid": hlr.get("valid"),
-                "country_name": hlr.get("country_name") or hlr.get("country"),
-                "country_code": hlr.get("country_code"),
-                "carrier": hlr.get("carrier"),
-                "line_type": hlr.get("line_type"),
-                "region": hlr.get("region"),
-                "timezones": hlr.get("timezones"),
-                "reverse": {
-                    "name": ", ".join(owner.get("names", [])) or None,
-                    "address": owner.get("city"),
-                    "source": ", ".join(owner.get("sources", [])) or None,
-                } if owner else None,
-            }
-
-    elif scan_type == "telegram":
-        _log("Running telegram ...")
-        from modules.telegram_lookup import TelegramLookup
-        from config import TELEGRAM_BOT_TOKEN
-        tg = TelegramLookup()
-        tg_target = target.lstrip("@").replace("t.me/", "").replace("telegram.me/", "").strip()
-        results["telegram"] = await _invoke(tg.run_lookup, tg_target, TELEGRAM_BOT_TOKEN or None)
+        type_modules = {
+            "gravatar": GravatarRecon,
+            "breach": BreachCheck,
+        }
 
     elif scan_type == "username":
-        if want("blackbird"):
-            _log("Running blackbird ...")
-            from modules.blackbird import Blackbird
-            bb = Blackbird(timeout=10, max_concurrent=25)
-            outcome = await _invoke(bb.search, target)
-            if isinstance(outcome, dict) and outcome.get("error"):
-                results["blackbird"] = outcome
+        type_modules = {
+            "github": GitHubRecon,
+        }
+
+    elif scan_type == "ip":
+        type_modules = {
+            "geoip": GeoIP,
+        }
+        if os.getenv("VIRUSTOTAL_API_KEY"):
+            type_modules["virustotal"] = VirusTotalLookup
+        if os.getenv("SHODAN_API_KEY"):
+            type_modules["shodan"] = ShodanLookup
+        if os.getenv("ABUSEIPDB_API_KEY"):
+            type_modules["abuseipdb"] = AbuseIPDBLookup
+
+    elif scan_type == "phone":
+        type_modules = {}
+
+    else:
+        type_modules = {}
+
+    # Combine modules
+    all_modules = {**common_modules, **type_modules}
+
+    # Filter if specific modules requested
+    if modules:
+        all_modules = {k: v for k, v in all_modules.items() if k in modules}
+
+    # Run each module
+    for name, handler in all_modules.items():
+        if verbose:
+            print(f"{Colors.CYAN}Running module: {name}{Colors.RESET}")
+
+        try:
+            if handler is None:
+                # Special handling for modules without a class
+                if name == "opsec":
+                    # OPSEC scoring is done after all modules
+                    continue
+                results[name] = {"error": "Module not available"}
+                continue
+
+            # Instantiate and run
+            instance = handler()
+            if hasattr(instance, "lookup"):
+                result = instance.lookup(target)
+            elif hasattr(instance, "search"):
+                result = instance.search(target)
+            elif hasattr(instance, "check"):
+                result = instance.check(target)
+            elif hasattr(instance, "run"):
+                result = instance.run(target)
             else:
-                results["blackbird"] = [
-                    {"site": r.site, "url": r.url, "status": r.status, "response_time": r.response_time}
-                    for r in bb.results
-                ]
+                result = {"error": f"Module {name} has no main method"}
 
-        if want("maigret"):
-            _log("Running maigret ...")
-            from modules.maigret_wrapper import MaigretWrapper
-            results["maigret"] = await _invoke(MaigretWrapper().search, target)
+            results[name] = result
 
-        if want("hudsonrock"):
-            _log("Running hudsonrock ...")
-            from modules.hudsonrock import HudsonRockLookup
-            results["hudsonrock"] = await _invoke(HudsonRockLookup().search_username, target)
+        except Exception as e:
+            results[name] = {"error": str(e)}
+            if verbose:
+                print(f"{Colors.RED}Error in {name}: {e}{Colors.RESET}")
 
-    _log("Computing opsec score ...")
-    from modules.opsec_score import score_from_results
-    opsec = score_from_results(results)
-    results["opsec_score"] = opsec
+    # Run OPSEC scoring
+    try:
+        from modules.opsec_scorer import score_results
+        results["opsec"] = score_results(results)
+    except Exception as e:
+        results["opsec"] = {"error": str(e)}
 
-    _log("Building graph ...")
-    from modules.graph_builder import build_graph
-    graph = build_graph(target, scan_type, results)
-    results["graph"] = graph
+    results["completed_at"] = datetime.now().isoformat()
+    results["status"] = "completed"
 
     return results
 
 
-async def _invoke(func, *args, **kwargs) -> Any:
-    try:
-        if asyncio.iscoroutinefunction(func):
-            return await func(*args, **kwargs)
-        loop = asyncio.get_event_loop()
-        return await loop.run_in_executor(None, lambda: func(*args, **kwargs))
-    except Exception as exc:
-        return {"error": str(exc)}
-
-
-def _serialisable(results: Dict[str, Any]) -> Dict[str, Any]:
-    skip = {"report_path"}
-    out = {}
-    for k, v in results.items():
-        if k in skip:
-            continue
-        out[k] = v
-    return out
-
-
-def output_json(results: Dict[str, Any], path: Optional[str] = None) -> None:
-    text = json.dumps(_serialisable(results), indent=2, default=str, ensure_ascii=False)
-    if path:
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(text)
-        print(f"Results saved to {path}", file=sys.stderr)
-    else:
-        print(text)
-
-
-def output_html(target: str, scan_type: str, results: Dict[str, Any], path: Optional[str] = None) -> None:
-    from modules.report_generator import generate_html_report
-    opsec = results.get("opsec_score")
-    report_path = generate_html_report(target, scan_type, results, opsec, output_path=path)
-    print(f"HTML report saved to {report_path}", file=sys.stderr)
-
-
-def output_pdf(target: str, scan_type: str, results: Dict[str, Any], path: Optional[str] = None) -> None:
-    from modules.report_generator import generate_pdf_report
-    opsec = results.get("opsec_score")
-    report_path = generate_pdf_report(target, scan_type, results, opsec, output_path=path)
-    print(f"PDF report saved to {report_path}", file=sys.stderr)
-
-
-def build_parser() -> argparse.ArgumentParser:
+def main(args=None):
+    """Main entry point for CLI."""
     parser = argparse.ArgumentParser(
-        prog="prism",
-        description="PRISM OSINT Platform - Command Line Interface",
+        description="PRISM - Open Source Intelligence Platform",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python cli.py scan example.com
+  python cli.py scan user@example.com --type email
+  python cli.py scan @username --type username
+  python cli.py scan 8.8.8.8 --type ip
+  python cli.py scan +1234567890 --type phone
+  python cli.py scan example.com --modules whois,dns,cert_transparency
+  python cli.py scan example.com --json -o results.json
+  python cli.py scan example.com --html -o report.html
+        """
     )
-    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
-    sub = parser.add_subparsers(dest="command")
 
-    scan_p = sub.add_parser("scan", help="Run an OSINT scan against a target")
-    scan_p.add_argument("target", help="Scan target (domain, IP, email, phone number, or username)")
-    scan_p.add_argument(
-        "--type", "-t",
-        dest="scan_type",
-        choices=["domain", "ip", "email", "phone", "username", "telegram"],
-        default=None,
-        help="Target type (auto-detected if omitted)",
-    )
-    scan_p.add_argument(
-        "--modules", "-m",
-        default=None,
-        help="Comma-separated list of modules to run (default: all applicable)",
-    )
-    scan_p.add_argument("--json", dest="fmt_json", action="store_true", default=False, help="Output JSON (default)")
-    scan_p.add_argument("--html", dest="fmt_html", action="store_true", default=False, help="Generate HTML report")
-    scan_p.add_argument("--pdf", dest="fmt_pdf", action="store_true", default=False, help="Generate PDF report")
-    scan_p.add_argument("--output", "-o", default=None, help="Output file path")
-    scan_p.add_argument("--verbose", "-v", action="store_true", default=False, help="Print progress to stderr")
-    scan_p.add_argument("--quiet", "-q", action="store_true", default=False, help="Print only the result (suppress banners and progress)")
+    subparsers = parser.add_subparsers(dest="command", help="Commands")
 
-    watch_p = sub.add_parser("watchlist", help="Manage scheduled re-scans")
-    watch_p.set_defaults(watch_parser=watch_p)
-    watch_sub = watch_p.add_subparsers(dest="watch_command")
+    # Scan command
+    scan_parser = subparsers.add_parser("scan", help="Run a scan")
+    scan_parser.add_argument("target", help="Target to scan (domain, email, IP, phone, username)")
+    scan_parser.add_argument("--type", choices=["domain", "email", "ip", "phone", "username"],
+                            help="Force target type (auto-detected if not specified)")
+    scan_parser.add_argument("--modules", help="Comma-separated list of modules to run")
+    scan_parser.add_argument("--json", "-j", action="store_true", help="Output results as JSON")
+    scan_parser.add_argument("--markdown", "-m", action="store_true", help="Output results as Markdown")
+    scan_parser.add_argument("--html", action="store_true", help="Output results as HTML")
+    scan_parser.add_argument("--output", "-o", help="Output file (for JSON/Markdown/HTML)")
+    scan_parser.add_argument("--verbose", "-v", action="store_true", help="Verbose output")
+    scan_parser.add_argument("--quiet", "-q", action="store_true", help="Quiet output (no banner)")
 
-    watch_list = watch_sub.add_parser("list", help="List watchlist entries")
-    watch_list.add_argument("--json", dest="fmt_json", action="store_true", default=False, help="Output JSON")
+    # Web command
+    web_parser = subparsers.add_parser("web", help="Start the web interface")
 
-    watch_add = watch_sub.add_parser("add", help="Add a target to the watchlist")
-    watch_add.add_argument("target", help="Target to re-scan on a schedule")
-    watch_add.add_argument(
-        "--type", "-t",
-        dest="scan_type",
-        choices=["domain", "ip", "email", "phone", "username", "telegram"],
-        default=None,
-        help="Target type (auto-detected if omitted)",
-    )
-    watch_add.add_argument("--modules", "-m", default=None, help="Comma-separated list of modules (default: all applicable)")
-    watch_add.add_argument("--interval", type=float, default=24.0, help="Hours between runs (default: 24)")
-    watch_add.add_argument("--webhook", default=None, help="Webhook URL to notify on changes")
+    # Parse arguments
+    parsed_args = parser.parse_args(args)
 
-    watch_rm = watch_sub.add_parser("rm", help="Remove a watchlist entry")
-    watch_rm.add_argument("id", help="Watchlist entry id")
+    if parsed_args.command == "scan":
+        target = parsed_args.target
+        if not target:
+            print("Error: No target specified")
+            sys.exit(1)
 
-    watch_pause = watch_sub.add_parser("pause", help="Pause a watchlist entry")
-    watch_pause.add_argument("id", help="Watchlist entry id")
+        # Normalize target
+        target = normalize_target(target)
 
-    watch_resume = watch_sub.add_parser("resume", help="Resume a paused watchlist entry")
-    watch_resume.add_argument("id", help="Watchlist entry id")
+        # Detect type if not specified
+        scan_type = parsed_args.type or detect_type(target)
 
-    return parser
+        # Parse modules
+        modules = None
+        if parsed_args.modules:
+            modules = [m.strip() for m in parsed_args.modules.split(",")]
 
+        # Print banner
+        if not parsed_args.quiet:
+            print_banner()
+            print(f"\n{Colors.YELLOW}Target:{Colors.RESET} {target}")
+            print(f"{Colors.YELLOW}Type:{Colors.RESET} {scan_type}")
+            if modules:
+                print(f"{Colors.YELLOW}Modules:{Colors.RESET} {', '.join(modules)}")
+            print()
 
-def _fmt_ts(ts: Optional[float]) -> str:
-    if not ts:
-        return "-"
-    return datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+        # Run scan
+        try:
+            results = asyncio.run(run_scan(target, scan_type, modules, parsed_args.verbose))
 
+            # Output results
+            if parsed_args.json:
+                output_json(results, parsed_args.output)
+            elif parsed_args.markdown:
+                markdown = output_markdown(results)
+                if parsed_args.output:
+                    with open(parsed_args.output, "w") as f:
+                        f.write(markdown)
+                else:
+                    print(markdown)
+            elif parsed_args.html:
+                try:
+                    from modules.report_generator import generate_html_report
+                    html = generate_html_report(results)
+                    if parsed_args.output:
+                        with open(parsed_args.output, "w") as f:
+                            f.write(html)
+                    else:
+                        print(html)
+                except ImportError as e:
+                    print(f"{Colors.RED}Error: {e}{Colors.RESET}")
+                    print("HTML report generation requires additional dependencies.")
+                    print("Install them with: pip install -r requirements-web.txt")
+                    sys.exit(1)
+            else:
+                # Default: print summary
+                print_summary(results)
 
-def run_watchlist(args: argparse.Namespace, parser: argparse.ArgumentParser) -> int:
-    from web import watchlist as wl
+            sys.exit(0)
 
-    command = getattr(args, "watch_command", None)
-    if command is None:
-        args.watch_parser.print_help()
-        return 1
+        except KeyboardInterrupt:
+            print(f"\n{Colors.YELLOW}Scan interrupted by user{Colors.RESET}")
+            sys.exit(1)
+        except Exception as e:
+            print(f"{Colors.RED}Error: {e}{Colors.RESET}")
+            if parsed_args.verbose:
+                import traceback
+                traceback.print_exc()
+            sys.exit(1)
 
-    if command == "list":
-        entries = wl.list_watchlists(wl.ANONYMOUS)
-        if getattr(args, "fmt_json", False):
-            print(json.dumps(entries, indent=2, default=str))
-            return 0
-        if not entries:
-            print("No watchlist entries. Add one with: prism watchlist add <target>")
-            return 0
-        print(f"{'ID':<38} {'TARGET':<28} {'TYPE':<9} {'EVERY':<7} {'STATUS':<10} NEXT RUN")
-        for e in entries:
-            status = "paused" if e.get("paused") else (e.get("last_status") or "pending")
-            interval = f"{e.get('interval_hours', 0):g}h"
-            print(
-                f"{e['id']:<38} {e['target'][:27]:<28} {e['scan_type']:<9} "
-                f"{interval:<7} {status:<10} {_fmt_ts(e.get('next_run'))}"
-            )
-        return 0
+    elif parsed_args.command == "web":
+        print("Starting web interface...")
+        print("Run: uvicorn web.app:app --host 0.0.0.0 --port 8080")
+        print("Or use Docker: docker compose up")
+        sys.exit(0)
 
-    if command == "add":
-        target = normalize_target(args.target)
-        scan_type = args.scan_type or detect_type(target)
-        modules = [m.strip() for m in args.modules.split(",") if m.strip()] if args.modules else None
-        interval = max(1.0, min(float(args.interval), 24 * 30))
-        entry = wl.create_watchlist(wl.ANONYMOUS, target, scan_type, modules, interval, args.webhook)
-        print(f"Watching {entry['target']} ({entry['scan_type']}) every {interval:g}h")
-        print(f"id: {entry['id']}")
-        return 0
-
-    if command == "rm":
-        if wl.delete_watchlist(args.id, wl.ANONYMOUS):
-            print(f"Removed {args.id}")
-            return 0
-        print(f"No watchlist entry with id {args.id}", file=sys.stderr)
-        return 1
-
-    if command in ("pause", "resume"):
-        entry = wl.set_paused(args.id, wl.ANONYMOUS, command == "pause")
-        if entry is None:
-            print(f"No watchlist entry with id {args.id}", file=sys.stderr)
-            return 1
-        print(f"{'Paused' if entry['paused'] else 'Resumed'} {entry['target']}")
-        return 0
-
-    args.watch_parser.print_help()
-    return 1
-
-
-def main(argv: Optional[List[str]] = None) -> None:
-    parser = build_parser()
-    args = parser.parse_args(argv)
-
-    if args.command is None:
+    else:
         parser.print_help()
         sys.exit(1)
 
-    if args.command == "watchlist":
-        sys.exit(run_watchlist(args, parser))
 
-    if args.command == "scan":
-        target = normalize_target(args.target)
-        scan_type = args.scan_type or detect_type(target)
-        modules = [m.strip() for m in args.modules.split(",") if m.strip()] if args.modules else None
+def print_summary(results: Dict[str, Any]) -> None:
+    """Print a summary of scan results."""
+    from config import Colors
 
-        verbose = args.verbose and not args.quiet
+    print(f"\n{Colors.CYAN}{'='*60}{Colors.RESET}")
+    print(f"{Colors.BOLD}Scan Results{Colors.RESET}")
+    print(f"{Colors.CYAN}{'='*60}{Colors.RESET}")
 
-        if verbose:
-            print(f"Target : {target}", file=sys.stderr)
-            print(f"Type   : {scan_type}", file=sys.stderr)
-            if modules:
-                print(f"Modules: {', '.join(modules)}", file=sys.stderr)
-            print(file=sys.stderr)
+    print(f"{Colors.YELLOW}Target:{Colors.RESET} {results.get('target', 'N/A')}")
+    print(f"{Colors.YELLOW}Type:{Colors.RESET} {results.get('scan_type', 'N/A')}")
+    print(f"{Colors.YELLOW}Started:{Colors.RESET} {results.get('started_at', 'N/A')}")
+    print(f"{Colors.YELLOW}Completed:{Colors.RESET} {results.get('completed_at', 'N/A')}")
+    print(f"{Colors.YELLOW}Status:{Colors.RESET} {results.get('status', 'N/A')}")
 
-        try:
-            results = asyncio.run(run_scan(target, scan_type, modules, verbose=verbose))
-        except KeyboardInterrupt:
-            print("\nScan interrupted.", file=sys.stderr)
-            sys.exit(1)
-        except Exception as exc:
-            print(f"Error: {exc}", file=sys.stderr)
-            sys.exit(1)
+    # OPSEC Score
+    opsec = results.get("opsec", {})
+    if opsec and not opsec.get("error"):
+        score = opsec.get("score", "N/A")
+        risk = opsec.get("risk_level", "N/A")
+        color = Colors.GREEN if score >= 70 else Colors.YELLOW if score >= 40 else Colors.RED
+        print(f"\n{Colors.BOLD}OPSEC Score:{Colors.RESET} {color}{score}/100{Colors.RESET} ({risk})")
 
-        output_path = args.output
+    # Module results
+    print(f"\n{Colors.BOLD}Module Results:{Colors.RESET}")
+    for key, value in results.items():
+        if key in ("target", "scan_type", "opsec", "started_at", "completed_at", "status"):
+            continue
+        if not value:
+            continue
 
-        if args.fmt_html:
-            output_html(target, scan_type, results, path=output_path)
-        elif args.fmt_pdf:
-            output_pdf(target, scan_type, results, path=output_path)
+        if isinstance(value, dict):
+            if value.get("error"):
+                status = f"{Colors.RED}ERROR{Colors.RESET}"
+            elif value.get("status") == "ok":
+                status = f"{Colors.GREEN}OK{Colors.RESET}"
+            else:
+                status = f"{Colors.YELLOW}{value.get('status', 'UNKNOWN')}{Colors.RESET}"
+            print(f"  {key}: {status}")
         else:
-            output_json(results, path=output_path)
+            print(f"  {key}: {type(value).__name__}")
 
-        if not args.quiet:
-            print(
-                "\n⭐ Found PRISM useful? Star it: "
-                "https://github.com/NovaCode37/Prism-platform",
-                file=sys.stderr,
-            )
-        sys.exit(0)
+    print(f"\n{Colors.CYAN}{'='*60}{Colors.RESET}")
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,427 +1,258 @@
 'use client';
-import { useState, useEffect, useRef } from 'react';
-import { Play, Loader2, ChevronDown, ChevronUp, Lightbulb, RotateCcw, Trash2, History, GitCompare, X } from 'lucide-react';
+
+import { useState, useEffect } from 'react';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  Home,
+  Search,
+  Clock,
+  Settings,
+  FileText,
+  Bell,
+  Moon,
+  Sun,
+  Globe,
+  Shield,
+  Users,
+  Mail,
+  Phone,
+  Server,
+  Network,
+  AlertTriangle,
+  Lock,
+  Key,
+  BarChart3,
+  Activity,
+  Database,
+  Cloud,
+  Code,
+  Eye,
+  EyeOff,
+  Menu,
+  X,
+  HelpCircle,
+  Keyboard,
+} from 'lucide-react';
+import { useTheme } from '@/lib/useTheme';
 import { useTranslations } from '@/lib/i18n';
-import { listScans, clearScans, type ScanListItem } from '@/lib/api';
-import type { ScanType } from '@/lib/types';
+import { Logo } from '@/components/Logo';
 
-const TYPE_COLOR: Record<ScanType, string> = {
-  domain:   'bg-blue/15 text-blue',
-  ip:       'bg-purple/15 text-purple',
-  email:    'bg-yellow/15 text-yellow',
-  phone:    'bg-green/15 text-green',
-  username: 'bg-red/15 text-red',
+// Map of module names to display labels
+export const MODULE_MAP: Record<string, { label: string; icon: string }> = {
+  whois: { label: 'WHOIS', icon: '📋' },
+  dns: { label: 'DNS', icon: '🌐' },
+  rdap: { label: 'RDAP', icon: '🔍' },
+  cert_transparency: { label: 'CT Logs', icon: '🔏' },
+  shodan: { label: 'Shodan', icon: '🔎' },
+  virustotal: { label: 'VirusTotal', icon: '🦠' },
+  abuseipdb: { label: 'AbuseIPDB', icon: '🚫' },
+  censys: { label: 'Censys', icon: '📡' },
+  geoip: { label: 'GeoIP', icon: '🗺️' },
+  gravatar: { label: 'Gravatar', icon: '👤' },
+  breach: { label: 'Breaches', icon: '💥' },
+  github: { label: 'GitHub', icon: '🐙' },
+  darkweb: { label: 'Dark Web', icon: '🌑' },
+  onion: { label: 'Onion Sites', icon: '🧅' },
+  wayback: { label: 'Wayback', icon: '🕰️' },
+  graph: { label: 'Graph', icon: '📊' },
+  opsec: { label: 'OPSEC', icon: '🛡️' },
 };
 
-interface RecentScan { target: string; type: ScanType; ts: number; }
-
-const SCAN_TYPES: ScanType[] = ['domain', 'ip', 'email', 'phone', 'username'];
-
-export const MODULE_MAP: Record<ScanType, string[]> = {
-  domain:   ['whois', 'dns', 'geoip', 'cert_transparency', 'website', 'wayback', 'shodan', 'virustotal', 'censys', 'onion', 'hudsonrock', 'lunar'],
-  ip:       ['geoip', 'shodan', 'virustotal', 'abuseipdb', 'censys'],
-  email:    ['emailrep', 'smtp', 'leaks', 'gravatar', 'hudsonrock'],
-  phone:    ['hlr'],
-  username: ['blackbird', 'maigret', 'github', 'hudsonrock'],
-};
-
-const MODULE_DESCRIPTIONS: Record<string, string> = {
-  whois: 'Look up domain registration and ownership details',
-  dns: 'Check DNS records and domain configuration',
-  geoip: 'Find approximate geographic information for an IP address',
-  cert_transparency: 'Search certificate transparency records and subdomains',
-  website: 'Analyze publicly available website information',
-  wayback: 'Search historical snapshots from the Wayback Machine',
-  shodan: 'Search Shodan for exposed services and ports',
-  virustotal: 'Check reputation and threat intelligence with VirusTotal',
-  censys: 'Search internet hosts, services, and certificates with Censys',
-  onion: 'Search for related information on dark web sources',
-  hudsonrock: 'Check infostealer exposure using Hudson Rock',
-  lunar: 'Check domain exposure trends and malware families using Lunar',
-  abuseipdb: 'Check IP reputation and abuse reports with AbuseIPDB',
-  emailrep: 'Check email reputation and risk indicators',
-  smtp: 'Verify email server and SMTP availability',
-  leaks: 'Check whether an email appears in known data breaches',
-  gravatar: 'Look up a public Gravatar profile associated with an email',
-  hlr: 'Look up phone number carrier and network information',
-  blackbird: 'Search for a username across online platforms with Blackbird',
-  maigret: 'Search for a username across websites with Maigret',
-  github: 'Search GitHub for information associated with a username',
-};
-
-interface Props {
-  onScan: (target: string, type: ScanType, modules: string[]) => void;
-  onLoadScan?: (scanId: string) => void;
-  onCompare?: (a: string, b: string) => void;
-  isRunning: boolean;
-  isStarting?: boolean;
+interface SidebarProps {
   isOpen: boolean;
   onClose: () => void;
 }
 
-function useRecentScans() {
-  const KEY = 'prism_recent_scans';
-  const [recents, setRecents] = useState<RecentScan[]>([]);
-
-  useEffect(() => {
-    try { setRecents(JSON.parse(localStorage.getItem(KEY) || '[]')); } catch {}
-  }, []);
-
-  const add = (target: string, type: ScanType) => {
-    setRecents(prev => {
-      const next = [{ target, type, ts: Date.now() }, ...prev.filter(r => r.target !== target)].slice(0, 6);
-      localStorage.setItem(KEY, JSON.stringify(next));
-      return next;
-    });
-  };
-
-  const clear = () => { localStorage.removeItem(KEY); setRecents([]); };
-
-  return { recents, add, clear };
-}
-
-export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isStarting = false, isOpen, onClose }: Props) {
+export function Sidebar({ isOpen, onClose }: SidebarProps) {
+  const pathname = usePathname();
+  const { theme, toggleTheme, mounted } = useTheme();
   const { t } = useTranslations();
-  const [target, setTarget] = useState('');
-  const [scanType, setScanType] = useState<ScanType>('domain');
-  const [modules, setModules] = useState<string[]>(MODULE_MAP.domain);
-  const [showModules, setShowModules] = useState(false);
-  const [tipIdx, setTipIdx] = useState(0);
-  const [tipVisible, setTipVisible] = useState(true);
-  const [showHistory, setShowHistory] = useState(false);
-  const [history, setHistory] = useState<ScanListItem[]>([]);
-  const [historyLoading, setHistoryLoading] = useState(false);
-  const [compareMode, setCompareMode] = useState(false);
-  const [compareSelection, setCompareSelection] = useState<string[]>([]);
-  const { recents, add: addRecent, clear: clearRecents } = useRecentScans();
+  const [isCollapsed, setIsCollapsed] = useState(false);
 
+  // Handle responsive collapse
   useEffect(() => {
-    const iv = setInterval(() => {
-      setTipVisible(false);
-      setTimeout(() => { setTipIdx(i => (i + 1) % SCAN_TYPES.length); setTipVisible(true); }, 350);
-    }, 4000);
-    return () => clearInterval(iv);
-  }, []);
-
-  const fetchHistory = async () => {
-    setHistoryLoading(true);
-    try {
-      const items = await listScans();
-      setHistory(items);
-    } catch {
-      setHistory([]);
-    }
-    setHistoryLoading(false);
-  };
-
-  const handleClearHistory = async () => {
-  const confirmed = window.confirm(
-    'Are you sure you want to clear your scan history?'
-  );
-
-  if (!confirmed) return;
-
-  try {
-    await clearScans();
-    await fetchHistory();
-  } catch (err) {
-    console.error(err);
-    alert('Failed to clear scan history');
-  }
-};
-
-  const toggleHistory = () => {
-    const next = !showHistory;
-    setShowHistory(next);
-    if (next) fetchHistory();
-  };
-
-  const prevRunning = useRef(isRunning);
-  const targetInputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key !== '/' || e.ctrlKey || e.metaKey || e.altKey) return;
-      const el = document.activeElement;
-      const tag = el?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || (el as HTMLElement)?.isContentEditable) return;
-      e.preventDefault();
-      targetInputRef.current?.focus();
+    const handleResize = () => {
+      if (window.innerWidth < 768) {
+        setIsCollapsed(true);
+      } else {
+        setIsCollapsed(false);
+      }
     };
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
   }, []);
+
+  // Close sidebar on route change (mobile)
   useEffect(() => {
-    if (prevRunning.current && !isRunning && showHistory) fetchHistory();
-    prevRunning.current = isRunning;
-  }, [isRunning, showHistory]);
-
-  const toggleCompareSelect = (id: string) => {
-    setCompareSelection(prev =>
-      prev.includes(id) ? prev.filter(x => x !== id) : prev.length < 2 ? [...prev, id] : [prev[1], id]
-    );
-  };
-
-  const handleTypeChange = (type: ScanType) => {
-    setScanType(type);
-    setModules(MODULE_MAP[type]);
-  };
-
-  const toggleModule = (id: string) => {
-    setModules(prev => prev.includes(id) ? prev.filter(m => m !== id) : [...prev, id]);
-  };
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (target.trim() && !isRunning) {
-      addRecent(target.trim(), scanType);
-      onScan(target.trim(), scanType, modules);
+    if (window.innerWidth < 768) {
+      onClose();
     }
-  };
+  }, [pathname, onClose]);
 
-  const loadRecent = (r: RecentScan) => {
-    setTarget(r.target);
-    handleTypeChange(r.type);
-  };
+  if (!mounted) return null;
 
-  const tip = t(`sidebar.tips.${tipIdx}`) || t('sidebar.tips.0');
+  const navItems = [
+    { href: '/', icon: Home, label: t('sidebar.home') },
+    { href: '/scan', icon: Search, label: t('sidebar.scan') },
+    { href: '/watchlist', icon: Bell, label: t('sidebar.watchlist') },
+    { href: '/reports', icon: FileText, label: t('sidebar.reports') },
+    { href: '/settings', icon: Settings, label: t('sidebar.settings') },
+  ];
+
+  const moduleItems = Object.entries(MODULE_MAP).map(([key, value]) => ({
+    key,
+    icon: value.icon,
+    label: value.label,
+  }));
 
   return (
-    <aside className={`fixed inset-y-0 left-0 z-50 w-64 bg-surface-1 border-r border-border-1 flex flex-col h-screen transform transition-transform duration-200 ease-in-out md:relative md:z-auto md:transform-none ${isOpen ? 'translate-x-0' : '-translate-x-full'}`}>
-      <button onClick={onClose} className="absolute top-3 right-3 md:hidden text-text-3 hover:text-text-1 p-1" aria-label="Close sidebar">✕</button>
-      <form onSubmit={handleSubmit} className="p-4 flex flex-col gap-3">
-        <div>
-          <label className="text-[10px] font-semibold text-text-3 uppercase tracking-wider block mb-1.5">{t('sidebar.target')}</label>
-          <div className="relative">
-            <input
-              ref={targetInputRef}
-              value={target}
-              onChange={e => setTarget(e.target.value)}
-              placeholder={t('sidebar.targetPlaceholder')}
-              aria-label={t('sidebar.target')}
-              className={`input-field ${target ? 'pr-7' : ''}`}
-              disabled={isRunning}
-            />
-            {target && (
-              <button
-                type="button"
-                onClick={() => setTarget('')}
-                aria-label="Clear target"
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-text-3 hover:text-text-1 transition-colors"
-              >
-                <X size={12} />
-              </button>
-            )}
-          </div>
-        </div>
+    <>
+      {/* Mobile overlay */}
+      {isOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 md:hidden"
+          onClick={onClose}
+        />
+      )}
 
-        <div>
-          <label className="text-[10px] font-semibold text-text-3 uppercase tracking-wider block mb-1.5">{t('sidebar.scanType')}</label>
-          <div className="grid grid-cols-3 gap-1">
-            {SCAN_TYPES.map(type => (
-              <button
-                key={type}
-                type="button"
-                onClick={() => handleTypeChange(type)}
-                aria-label={t(`sidebar.scanTypes.${type}`)}
-                aria-pressed={scanType === type}
-                className={`text-[10px] font-semibold py-1.5 rounded transition-all ${
-                  scanType === type ? 'text-white' : 'bg-surface-3 text-text-3 hover:text-text-2'
-                }`}
-                style={scanType === type ? { background: 'linear-gradient(135deg,#4f8ef7,#7c5cfc)' } : {}}
-              >
-                {t(`sidebar.scanTypes.${type}`)}
-              </button>
-            ))}
-          </div>
-        </div>
-
-        <button
-          type="button"
-          onClick={() => setShowModules(v => !v)}
-          className="flex items-center justify-between text-[10px] font-semibold text-text-3 uppercase tracking-wider hover:text-text-2 transition-colors"
-        >
-          {t('sidebar.modulesTitle')} ({modules.length}/{MODULE_MAP[scanType].length})
-          {showModules ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-        </button>
-
-        {showModules && (
-          <div className="flex flex-wrap gap-1.5 animate-fade-in">
-            {MODULE_MAP[scanType].map(moduleId => (
-              <button
-                key={moduleId}
-                type="button"
-                onClick={() => toggleModule(moduleId)}
-                aria-pressed={modules.includes(moduleId)}
-                title={MODULE_DESCRIPTIONS[moduleId] || t(`sidebar.modules.${moduleId}`)}
-                className={`text-[10px] px-2 py-1 rounded transition-all font-medium ${
-                  modules.includes(moduleId)
-                    ? 'bg-blue/20 text-blue border border-blue/30'
-                    : 'bg-surface-3 text-text-3 border border-border-1 hover:text-text-2'
-                }`}
-              >
-                {t(`sidebar.modules.${moduleId}`)}
-              </button>
-            ))}
-          </div>
-        )}
-
-        <button
-          type="submit"
-          disabled={!target.trim() || isRunning || isStarting || modules.length === 0}
-          className="btn-primary mt-1"
-        >
-          {(isRunning || isStarting) ? <Loader2 size={13} className="spin" /> : <Play size={13} />}
-          {isRunning ? t('sidebar.scanning') : isStarting ? t('sidebar.scanning') : t('sidebar.runScan')}
-        </button>
-      </form>
-
-      <div className="px-4 pb-3 flex-1">
-        <div className="border-t border-border-1 pt-3">
-          <div className="flex items-center justify-between mb-2">
-            <div className="flex items-center gap-1.5 text-[10px] font-semibold text-text-3 uppercase tracking-wider">
-              <RotateCcw size={9} />
-              {t('sidebar.recent')}
-            </div>
-            {recents.length > 0 && (
-              <button onClick={clearRecents} className="text-text-3 hover:text-red transition-colors" aria-label="Clear recent scans">
-                <Trash2 size={10} />
-              </button>
-            )}
-          </div>
-
-          {recents.length === 0 ? (
-            <div className="text-[10px] text-text-3 italic text-center py-1">{t('sidebar.noRecent')}</div>
-          ) : (
-            <div className="flex flex-col gap-1">
-              {recents.map((r, i) => (
-                <button
-                  key={i}
-                  onClick={() => loadRecent(r)}
-                  className="flex items-center gap-2 w-full text-left px-2 py-1.5 rounded hover:bg-surface-3 transition-colors group"
-                >
-                  <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded uppercase shrink-0 ${TYPE_COLOR[r.type]}`}>
-                    {r.type.slice(0, 2)}
-                  </span>
-                  <span className="text-[11px] text-text-2 truncate font-mono group-hover:text-text-1 transition-colors">
-                    {r.target}
-                  </span>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
-
-      <div className="border-t border-border-1 px-4 py-2">
-        <button
-          onClick={toggleHistory}
-          className="flex items-center justify-between w-full text-[10px] font-semibold text-text-3 uppercase tracking-wider hover:text-text-2 transition-colors mb-1"
-        >
-          <span className="flex items-center gap-1.5"><History size={10} /> {t('sidebar.history')}</span>
-          {showHistory ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-        </button>
-        {showHistory && (
-          <div className="animate-fade-in">
-            {compareMode && compareSelection.length === 2 && onCompare && (
-              <button
-                onClick={() => { onCompare(compareSelection[0], compareSelection[1]); setCompareMode(false); setCompareSelection([]); }}
-                className="btn-primary w-full text-[10px] py-1 mb-2"
-              >
-                <GitCompare size={10} /> {t('sidebar.compareSelected')}
-              </button>
-            )}
-
-
-
-
-            <div className="flex items-center gap-1 mb-1.5">
-              <button
-                onClick={() => { setCompareMode(v => !v); setCompareSelection([]); }}
-                className={`text-[9px] px-1.5 py-0.5 rounded transition-all font-medium ${
-                  compareMode ? 'bg-purple/20 text-purple border border-purple/30' : 'bg-surface-3 text-text-3 border border-border-1 hover:text-text-2'
-                }`}
-              >
-                
-                <span className="flex items-center gap-1"><GitCompare size={8} /> {t('sidebar.compare')}</span>
-              </button>
-
-  <button
-    onClick={handleClearHistory}
-    className="text-text-3 hover:text-red transition-colors"
-    aria-label="Clear scan history"
-  >
-    <Trash2 size={10} />
-  </button>
-
-
-              <button onClick={fetchHistory} className="text-text-3 hover:text-text-2 transition-colors ml-auto" aria-label="Refresh history">
-                <RotateCcw size={10} className={historyLoading ? 'spin' : ''} />
-              </button>
-            </div>
-
-
-
-
-
-
-            {historyLoading ? (
-              <div className="flex justify-center py-2"><Loader2 size={14} className="spin text-text-3" /></div>
-            ) : history.length === 0 ? (
-              <div className="text-[10px] text-text-3 opacity-40 italic">{t('sidebar.noHistory')}</div>
+      {/* Sidebar */}
+      <aside
+        className={`
+          fixed top-0 left-0 z-50 h-full bg-surface-1 border-r border-border-1 transition-all duration-300
+          ${isOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'}
+          ${isCollapsed ? 'w-16' : 'w-64'}
+        `}
+      >
+        <div className="flex h-full flex-col">
+          {/* Header */}
+          <div className="flex items-center justify-between h-16 px-4 border-b border-border-1">
+            {!isCollapsed ? (
+              <Link href="/" className="flex items-center gap-2" onClick={onClose}>
+                <Logo size={32} />
+                <span className="font-bold text-lg bg-gradient-to-r from-blue to-purple bg-clip-text text-transparent">
+                  PRISM
+                </span>
+              </Link>
             ) : (
-              <div className="flex flex-col gap-0.5 max-h-40 overflow-y-auto">
-                {history.map(h => {
-                  const selected = compareSelection.includes(h.scan_id);
-                  return (
-                    <button
-                      key={h.scan_id}
-                      onClick={() => compareMode ? toggleCompareSelect(h.scan_id) : onLoadScan?.(h.scan_id)}
-                      className={`flex items-center gap-2 w-full text-left px-2 py-1.5 rounded transition-colors group ${
-                        selected ? 'bg-purple/15 border border-purple/30' : 'hover:bg-surface-3'
-                      }`}
-                    >
-                      {compareMode && (
-                        <span className={`w-3 h-3 rounded-sm border shrink-0 flex items-center justify-center text-[8px] ${
-                          selected ? 'bg-purple border-purple text-white' : 'border-border-1'
-                        }`}>
-                          {selected ? '✓' : ''}
-                        </span>
-                      )}
-                      <span className={`text-[9px] font-bold px-1.5 py-0.5 rounded uppercase shrink-0 ${
-                        TYPE_COLOR[h.scan_type as ScanType] || 'bg-surface-3 text-text-3'
-                      }`}>
-                        {h.scan_type.slice(0, 2)}
-                      </span>
-                      <div className="flex flex-col min-w-0">
-                        <span className="text-[11px] text-text-2 truncate font-mono group-hover:text-text-1 transition-colors">
-                          {h.target}
-                        </span>
-                        <span className="text-[8px] text-text-3">
-                          {h.status === 'completed' ? '✓' : h.status === 'running' ? '...' : '✗'}{' '}
-                          {new Date(h.started_at).toLocaleDateString()}
-                        </span>
-                      </div>
-                    </button>
-                  );
-                })}
+              <Link href="/" className="mx-auto" onClick={onClose}>
+                <Logo size={32} />
+              </Link>
+            )}
+            <button
+              onClick={() => setIsCollapsed(!isCollapsed)}
+              className="hidden md:flex p-1 rounded hover:bg-surface-2 text-text-3"
+            >
+              {isCollapsed ? <Menu size={18} /> : <X size={18} />}
+            </button>
+            <button
+              onClick={onClose}
+              className="md:hidden p-1 rounded hover:bg-surface-2 text-text-3"
+            >
+              <X size={20} />
+            </button>
+          </div>
+
+          {/* Navigation */}
+          <nav className="flex-1 overflow-y-auto p-2 space-y-1">
+            {navItems.map((item) => {
+              const isActive = pathname === item.href;
+              return (
+                <Link
+                  key={item.href}
+                  href={item.href}
+                  onClick={onClose}
+                  className={`
+                    flex items-center gap-3 px-3 py-2 rounded transition-colors
+                    ${isActive ? 'bg-surface-2 text-text-1' : 'text-text-2 hover:bg-surface-2 hover:text-text-1'}
+                    ${isCollapsed ? 'justify-center' : ''}
+                  `}
+                  title={isCollapsed ? item.label : undefined}
+                >
+                  <item.icon size={isCollapsed ? 20 : 18} />
+                  {!isCollapsed && <span>{item.label}</span>}
+                </Link>
+              );
+            })}
+
+            {!isCollapsed && (
+              <>
+                <div className="h-px bg-border-1 my-2" />
+                <div className="px-3 py-1 text-xs font-semibold text-text-3 uppercase tracking-wider">
+                  {t('sidebar.modules')}
+                </div>
+              </>
+            )}
+
+            {moduleItems.map((item) => (
+              <Link
+                key={item.key}
+                href={`/scan?module=${item.key}`}
+                onClick={onClose}
+                className={`
+                  flex items-center gap-3 px-3 py-2 rounded transition-colors text-text-2 hover:bg-surface-2 hover:text-text-1
+                  ${isCollapsed ? 'justify-center' : ''}
+                `}
+                title={isCollapsed ? item.label : undefined}
+              >
+                <span className="text-base">{item.icon}</span>
+                {!isCollapsed && <span className="text-sm">{item.label}</span>}
+              </Link>
+            ))}
+          </nav>
+
+          {/* Footer */}
+          <div className="border-t border-border-1 p-2 space-y-1">
+            <button
+              onClick={toggleTheme}
+              className={`
+                flex items-center gap-3 px-3 py-2 rounded w-full transition-colors text-text-2 hover:bg-surface-2 hover:text-text-1
+                ${isCollapsed ? 'justify-center' : ''}
+              `}
+              title={isCollapsed ? (theme === 'dark' ? 'Light mode' : 'Dark mode') : undefined}
+            >
+              {theme === 'dark' ? (
+                <Sun size={isCollapsed ? 20 : 18} />
+              ) : (
+                <Moon size={isCollapsed ? 20 : 18} />
+              )}
+              {!isCollapsed && <span>{theme === 'dark' ? t('sidebar.lightMode') : t('sidebar.darkMode')}</span>}
+            </button>
+
+            <button
+              className={`
+                flex items-center gap-3 px-3 py-2 rounded w-full transition-colors text-text-2 hover:bg-surface-2 hover:text-text-1
+                ${isCollapsed ? 'justify-center' : ''}
+              `}
+              title={isCollapsed ? t('sidebar.shortcuts') : undefined}
+            >
+              <Keyboard size={isCollapsed ? 20 : 18} />
+              {!isCollapsed && <span>{t('sidebar.shortcuts')}</span>}
+            </button>
+
+            <Link
+              href="https://github.com/NovaCode37/Prism-platform"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={`
+                flex items-center gap-3 px-3 py-2 rounded w-full transition-colors text-text-2 hover:bg-surface-2 hover:text-text-1
+                ${isCollapsed ? 'justify-center' : ''}
+              `}
+              title={isCollapsed ? 'GitHub' : undefined}
+            >
+              <Code size={isCollapsed ? 20 : 18} />
+              {!isCollapsed && <span>GitHub</span>}
+            </Link>
+
+            {!isCollapsed && (
+              <div className="px-3 py-2 text-[10px] text-text-3 text-center">
+                v2.8.0 · MIT License
               </div>
             )}
           </div>
-        )}
-      </div>
-
-      <div className="border-t border-border-1 px-3 py-2.5">
-        <div className="flex items-center justify-center gap-1.5">
-          <Lightbulb size={10} className="text-yellow mt-0.5 shrink-0" />
-          <span
-            className="text-[10px] text-text-2 leading-relaxed text-center"
-            style={{ opacity: tipVisible ? 1 : 0, transition: 'opacity 0.3s ease' }}
-          >
-            {tip}
-          </span>
         </div>
-      </div>
-    </aside>
+      </aside>
+    </>
   );
 }

--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -1,1868 +1,432 @@
 'use client';
-import { useState, useEffect, useRef } from 'react';
-import { ExternalLink, Printer, Download, Shield, AlertTriangle, Globe, Server, Lock, User, Clock, Zap, Phone, MessageCircle, Map, GitBranch, Code, Brain, ChevronDown, ChevronUp, SendHorizontal, Mail, Copy, Eye, ShieldAlert, ArrowUp, FileSpreadsheet, FileText, Search, RefreshCw, Loader2, Github, UserCircle, TrendingUp } from 'lucide-react';
-import type { ScanResults, ScanMeta, OpsecFinding, ModuleStatus, ModuleStatusFields, ScanType } from '@/lib/types';
-import { fetchReportBlob, fetchGraphExport, generateAiSummary, sendAiChat, getMapData, getGraphData, startScan, getScan } from '@/lib/api';
+
+import { useState, useMemo } from 'react';
+import {
+  Download,
+  FileText,
+  Share2,
+  ChevronDown,
+  ChevronRight,
+  Check,
+  X,
+  AlertTriangle,
+  Info,
+  Wifi,
+  Shield,
+  Globe,
+  Database,
+  Clock,
+  Mail,
+  User,
+  Server,
+  Network,
+  MapPin,
+  File,
+  Link2,
+  Code,
+  Eye,
+  EyeOff,
+  Sparkles,
+  Loader2,
+} from 'lucide-react';
 import { useTranslations } from '@/lib/i18n';
+import { getPrismApiUrl, getPrismApiKey, buildApiUrl } from '@/lib/url-utils';
+import { MODULE_MAP } from '@/components/Sidebar';
 
-type MapMarker = {
-  lat: number;
-  lng: number;
-  label: string;
-  city?: string;
-  country?: string;
-  org?: string;
-  ip?: string;
-  approximate?: boolean;
-  precision?: string;
-  bbox?: number[];
-};
-
-type MapData = {
-  markers: MapMarker[];
-  center: { lat: number; lng: number } | null;
-  zoom?: number | null;
-  info?: { reason?: string; country?: string | null; carrier?: string | null; region?: string | null } | null;
-};
-
-let leafletLoader: Promise<any> | null = null;
-
-function escapeHtml(s: string): string {
-  return s.replace(/[&<>"']/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c] as string));
+interface ScanResultsProps {
+  results: Record<string, any>;
+  target: string;
+  scanType: string;
+  scanId: string;
 }
 
-function filenameSegment(value: string): string {
-  return value.trim().replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '') || 'scan';
-}
+const SEVERITY_ORDER = ['CRITICAL', 'HIGH', 'MEDIUM', 'LOW', 'INFO'];
 
-function loadLeaflet(): Promise<any> {
-  const w = window as any;
-  if (w.L) return Promise.resolve(w.L);
-  if (leafletLoader) return leafletLoader;
-  leafletLoader = new Promise((resolve, reject) => {
-    if (!document.querySelector('link[data-leaflet]')) {
-      const link = document.createElement('link');
-      link.rel = 'stylesheet';
-      link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css';
-      link.setAttribute('data-leaflet', '1');
-      document.head.appendChild(link);
-    }
-    const existing = document.querySelector('script[data-leaflet]') as HTMLScriptElement | null;
-    if (existing) {
-      existing.addEventListener('load', () => resolve((window as any).L), { once: true });
-      existing.addEventListener('error', () => reject(new Error('Failed to load Leaflet')), { once: true });
-      return;
-    }
-    const s = document.createElement('script');
-    s.src = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.js';
-    s.setAttribute('data-leaflet', '1');
-    s.onload = () => resolve((window as any).L);
-    s.onerror = () => reject(new Error('Failed to load Leaflet'));
-    document.head.appendChild(s);
-  });
-  return leafletLoader;
-}
-
-function MapView({ scanId, onCopy }: { scanId: string; onCopy: (value: string) => void }) {
-  const [data, setData] = useState<MapData | null>(null);
-  const [error, setError] = useState('');
-  const mapHostRef = useRef<HTMLDivElement>(null);
-  const mapRef = useRef<any>(null);
-  const markersRef = useRef<any>(null);
-
-  useEffect(() => {
-    getMapData(scanId)
-      .then((d: any) => { if (d.error) setError(d.error); else setData(d as MapData); })
-      .catch(e => setError(e.message));
-  }, [scanId]);
-
-  useEffect(() => {
-    if (!data?.markers?.length || !mapHostRef.current) return;
-    let cancelled = false;
-    loadLeaflet()
-      .then((L) => {
-        if (cancelled || !mapHostRef.current) return;
-        if (!mapRef.current) {
-          mapRef.current = L.map(mapHostRef.current, { zoomControl: true });
-          mapRef.current.attributionControl.setPrefix('<a href="https://leafletjs.com" target="_blank" rel="noopener noreferrer">Leaflet</a>');
-          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; OpenStreetMap', maxZoom: 18,
-          }).addTo(mapRef.current);
-        }
-
-        if (markersRef.current) markersRef.current.clearLayers();
-        else markersRef.current = L.layerGroup().addTo(mapRef.current);
-
-        const bounds: [number, number][] = [];
-        for (const m of data.markers) {
-          if (!Number.isFinite(m.lat) || !Number.isFinite(m.lng)) continue;
-          const parts = [
-            m.ip ? `IP: ${escapeHtml(m.ip)}` : '',
-            m.city || m.country ? `Location: ${escapeHtml([m.city, m.country].filter(Boolean).join(', '))}` : '',
-            m.org ? `Organization: ${escapeHtml(m.org)}` : '',
-            m.precision ? `Precision: ${escapeHtml(m.precision)}` : '',
-          ].filter(Boolean);
-          const popup = `<b>${escapeHtml(m.label || m.ip || 'Location')}</b><br/>${parts.join('<br/>')}`;
-          const hasBbox = m.approximate && Array.isArray(m.bbox) && m.bbox.length === 4;
-          if (hasBbox) {
-            const sw: [number, number] = [m.bbox![0], m.bbox![2]];
-            const ne: [number, number] = [m.bbox![1], m.bbox![3]];
-            L.rectangle([sw, ne], { color: '#4f8ef7', weight: 1, fillColor: '#4f8ef7', fillOpacity: 0.10 })
-              .bindPopup(`${popup}<br/><i>Approximate ${escapeHtml(m.precision || 'area')}-level - phone numbers don't expose an exact location</i>`)
-              .addTo(markersRef.current);
-            bounds.push(sw, ne);
-          } else if (m.approximate) {
-            const radius = m.precision === 'country' ? 250000 : 70000;
-            L.circle([m.lat, m.lng], { radius, color: '#4f8ef7', weight: 1, fillColor: '#4f8ef7', fillOpacity: 0.12 })
-              .bindPopup(`${popup}<br/><i>Approximate ${escapeHtml(m.precision || 'area')}-level location</i>`)
-              .addTo(markersRef.current);
-            bounds.push([m.lat, m.lng]);
-          } else {
-            L.marker([m.lat, m.lng]).bindPopup(popup).addTo(markersRef.current);
-            bounds.push([m.lat, m.lng]);
-          }
-        }
-
-        if (bounds.length === 1) {
-          mapRef.current.setView(bounds[0], typeof data.zoom === 'number' ? data.zoom : 10);
-        } else if (bounds.length > 1) {
-          mapRef.current.fitBounds(bounds, { padding: [24, 24] });
-        }
-
-        requestAnimationFrame(() => {
-          if (!cancelled && mapRef.current) mapRef.current.invalidateSize();
-        });
-      })
-      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to render map'));
-
-    return () => {
-      cancelled = true;
-    };
-  }, [data]);
-
-  useEffect(() => () => {
-    if (mapRef.current) {
-      mapRef.current.remove();
-      mapRef.current = null;
-      markersRef.current = null;
-    }
-  }, []);
-
-  if (error) return <div className="text-red text-sm">{error}</div>;
-  if (!data) return <div className="text-text-3 text-sm animate-pulse">Loading map...</div>;
-  if (!data.markers?.length) {
-    if (data.info && (data.info.country || data.info.carrier || data.info.region)) {
-      return (
-        <div className="text-[12px]">
-          <div className="text-text-2 mb-2">{data.info.reason || 'No precise coordinates available.'}</div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-1.5 max-w-md">
-            {data.info.country && <div className="dt-row"><span className="dt-label">Country</span><span className="dt-value">{data.info.country}</span></div>}
-            {data.info.region && <div className="dt-row"><span className="dt-label">Region</span><span className="dt-value">{data.info.region}</span></div>}
-            {data.info.carrier && <div className="dt-row"><span className="dt-label">Carrier</span><span className="dt-value">{data.info.carrier}</span></div>}
-          </div>
-        </div>
-      );
-    }
-    return <div className="text-text-3 text-sm">No geolocation data available</div>;
-  }
-
-  const m = data.markers[0];
-
-  return (
-    <div>
-      <div ref={mapHostRef} className="w-full rounded-md border border-border-1 h-64 sm:h-[360px]" />
-      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-1.5 text-[12px]">
-        {m.ip && (
-          <div className="dt-row">
-            <span className="dt-label">IP</span>
-            <div className="flex items-center gap-1.5">
-              <span className="dt-value font-mono">{m.ip}</span>
-              <CopyIconButton onClick={() => onCopy(m.ip ?? '')} label="Copy IP" />
-            </div>
-          </div>
-        )}
-        {(m.city || m.country) && <div className="dt-row"><span className="dt-label">Location</span><span className="dt-value">{[m.city, m.country].filter(Boolean).join(', ')}</span></div>}
-        {m.org && <div className="dt-row"><span className="dt-label">Organization</span><span className="dt-value">{m.org}</span></div>}
-        <div className="dt-row"><span className="dt-label">Coordinates</span><span className="dt-value font-mono">{m.lat.toFixed(4)}, {m.lng.toFixed(4)}</span></div>
-        {m.precision && <div className="dt-row"><span className="dt-label">Precision</span><span className="dt-value">{m.precision}</span></div>}
-        {m.approximate && <div className="dt-row"><span className="dt-label">Approximate</span><span className="dt-value">Yes</span></div>}
-      </div>
-      {data.markers.length > 1 && (
-        <div className="mt-3 text-[10px] text-text-3">{data.markers.length} locations found</div>
-      )}
-    </div>
-  );
-}
-
-// Mirrors NODE_COLORS + _shape in modules/graph_builder.py exactly.
-const LEGEND_ITEMS = [
-  { type: 'target',        color: '#00d4ff', label: 'Target' },
-  { type: 'email',         color: '#ff9f43', label: 'Email' },
-  { type: 'domain',        color: '#a29bfe', label: 'Domain' },
-  { type: 'subdomain',     color: '#74b9ff', label: 'Subdomain' },
-  { type: 'ip',            color: '#fd79a8', label: 'IP Address' },
-  { type: 'account',       color: '#55efc4', label: 'Account' },
-  { type: 'technology',    color: '#636e72', label: 'Technology' },
-  { type: 'vulnerability', color: '#d63031', label: 'Vulnerability' },
-  { type: 'organization',  color: '#fdcb6e', label: 'Organization' },
-  { type: 'url',           color: '#81ecec', label: 'URL' },
-] as const;
-
-function GraphLegend() {
-  return (
-    <div className="mt-3 flex flex-wrap gap-x-4 gap-y-2 px-1">
-      {LEGEND_ITEMS.map(({ type, color, label }) => (
-        <div key={type} className="flex items-center gap-1.5">
-          <span
-            className="inline-block h-2.5 w-2.5 rounded-full shrink-0"
-            style={{ background: color }}
-            aria-hidden
-          />
-          <span className="text-[11px] text-text-3 capitalize">{label}</span>
-        </div>
-      ))}
-    </div>
-  );
-}
-
-function GraphView({ scanId }: { scanId: string }) {
+export function ScanResults({ results, target, scanType, scanId }: ScanResultsProps) {
   const { t } = useTranslations();
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [status, setStatus] = useState<'loading' | 'ready' | 'empty' | 'error'>('loading');
-  const [error, setError] = useState('');
+  const [expandedModules, setExpandedModules] = useState<Set<string>>(new Set());
+  const [showRaw, setShowRaw] = useState(false);
 
-  useEffect(() => {
-    let cancelled = false;
-    const init = async () => {
-      try {
-        const graphData: any = await getGraphData(scanId);
-        if (!graphData.nodes?.length) { setStatus('empty'); return; }
+  const toggleModule = (module: string) => {
+    setExpandedModules((prev) => {
+      const next = new Set(prev);
+      if (next.has(module)) {
+        next.delete(module);
+      } else {
+        next.add(module);
+      }
+      return next;
+    });
+  };
 
-        const loadVis = () => new Promise<void>((resolve, reject) => {
-          if ((window as { vis?: unknown }).vis) { resolve(); return; }
-          const s = document.createElement('script');
-          s.src = 'https://unpkg.com/vis-network/standalone/umd/vis-network.min.js';
-          s.onload = () => resolve();
-          s.onerror = () => reject(new Error('Failed to load vis-network'));
-          document.head.appendChild(s);
+  // Extract findings
+  const findings = useMemo(() => {
+    const items: Array<{ severity: string; message: string; source: string }> = [];
+
+    // Check each module for findings
+    for (const [key, value] of Object.entries(results)) {
+      if (!value || typeof value !== 'object') continue;
+
+      // Shodan vulns
+      if (key === 'shodan' && value.vulns) {
+        for (const vuln of value.vulns) {
+          items.push({
+            severity: value.vuln_severity?.[vuln] || 'MEDIUM',
+            message: `${vuln}: ${value.vuln_summary?.[vuln] || 'Vulnerability found'}`,
+            source: 'Shodan',
+          });
+        }
+      }
+
+      // VirusTotal detections
+      if (key === 'virustotal' && value.malicious > 0) {
+        items.push({
+          severity: value.malicious > 3 ? 'HIGH' : 'MEDIUM',
+          message: `${value.malicious} malicious detections out of ${value.total} scanners`,
+          source: 'VirusTotal',
         });
-        await loadVis();
-
-        if (cancelled || !containerRef.current) return;
-        const vis = (window as any).vis;
-        new vis.Network(
-          containerRef.current,
-          { nodes: new vis.DataSet(graphData.nodes), edges: new vis.DataSet(graphData.edges || []) },
-          {
-            nodes: { font: { color: '#e6edf3', size: 11, face: 'Inter' }, borderWidth: 2, borderWidthSelected: 3 },
-            edges: { color: { color: '#4a5568', highlight: '#4f8ef7' }, font: { color: '#94a3b8', size: 9 }, smooth: { type: 'dynamic' } },
-            physics: { stabilization: { iterations: 300 }, barnesHut: { gravitationalConstant: -8000 } },
-            background: { color: 'transparent' },
-            interaction: { hover: true, tooltipDelay: 100 },
-          }
-        );
-        setStatus('ready');
-      } catch (e) { if (!cancelled) { setError(e instanceof Error ? e.message : 'Error'); setStatus('error'); } }
-    };
-    init();
-    return () => { cancelled = true; };
-  }, [scanId]);
-
-  return (
-    <div>
-      {status === 'loading' && <div className="text-text-3 text-sm animate-pulse py-4">Loading graph...</div>}
-      {status === 'empty' && (
-        <div className="flex flex-col items-center justify-center py-12 text-center">
-          <GitBranch size={28} className="text-text-3 opacity-40 mb-2" />
-          <div className="text-text-3 text-sm">{t('results.graph.empty')}</div>
-        </div>
-      )}
-      {status === 'error' && <div className="text-red text-sm py-4">{error}</div>}
-      <div ref={containerRef} className="h-72 sm:h-[480px]" style={{ height: status === 'ready' ? undefined : 0, background: 'transparent' }} />
-      {status === 'ready' && <GraphLegend />}
-    </div>
-  );
-}
-
-const RISK_COLOR: Record<string, string> = {
-  CRITICAL: '#f85149', HIGH: '#f85149', MEDIUM: '#d29922', LOW: '#3fb950', MINIMAL: '#3fb950'
-};
-
-function DtRow({ label, value }: { label: string; value?: string | number | null }) {
-  if (!value && value !== 0) return null;
-  return (
-    <div className="dt-row">
-      <span className="dt-label">{label}</span>
-      <span className="dt-value font-mono text-[11px]">{String(value)}</span>
-    </div>
-  );
-}
-
-function Card({ title, extra, children, onRefresh, refreshing = false }: { title?: string; extra?: React.ReactNode; children: React.ReactNode; onRefresh?: () => void; refreshing?: boolean }) {
-  return (
-    <div className="card mb-3">
-      {title && (
-        <div className="card-head flex items-center justify-between gap-2">
-          <span>{title}</span>
-          <div className="flex items-center gap-2">
-            {extra}
-            {onRefresh && (
-              <button
-                type="button"
-                onClick={onRefresh}
-                disabled={refreshing}
-                className="text-text-3 hover:text-text-1 transition-colors p-1 rounded-sm hover:bg-surface-2 disabled:cursor-wait disabled:opacity-70"
-                title={refreshing ? 'Refreshing...' : 'Refresh module'}
-                aria-label={refreshing ? 'Refreshing module' : 'Refresh module'}
-              >
-                {refreshing ? <Loader2 size={12} className="animate-spin" /> : <RefreshCw size={12} />}
-              </button>
-            )}
-          </div>
-        </div>
-      )}
-      <div className="p-4">{children}</div>
-    </div>
-  );
-}
-
-function modStatus(m?: (ModuleStatusFields & { error?: string | null }) | null): ModuleStatus {
-  if (!m) return 'ok';
-  if (m.status === 'skipped' || m.status === 'rate_limited' || m.status === 'error') return m.status;
-  if (m.error) return 'error';
-  return 'ok';
-}
-
-const STATUS_BADGE: Record<Exclude<ModuleStatus, 'ok'>, { label: string; color: string; hint: string }> = {
-  skipped: { label: 'SKIPPED', color: '#8b949e', hint: 'No API key configured' },
-  rate_limited: { label: 'RATE LIMITED', color: '#d29922', hint: 'Provider rate limit reached' },
-  error: { label: 'ERROR', color: '#f85149', hint: 'Module failed' },
-};
-
-function ModuleStatusBadge({ status, label }: { status: ModuleStatus; label?: string }) {
-  if (status === 'ok') return null;
-  const b = STATUS_BADGE[status];
-  return (
-    <span
-      className="text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded border"
-      style={{ color: b.color, borderColor: `${b.color}55`, background: `${b.color}11` }}
-    >
-      {label ?? b.label}
-    </span>
-  );
-}
-
-function ModuleNotice({ status, reason }: { status: 'skipped' | 'rate_limited'; reason?: string }) {
-  const b = STATUS_BADGE[status];
-  return (
-    <div className="text-[12px]" style={{ color: status === 'rate_limited' ? b.color : undefined }}>
-      <span className="text-text-2">{reason || b.hint}</span>
-      {status === 'skipped' && (
-        <span className="text-text-3"> - add the key to <code className="font-mono">.env</code> to enable this module.</span>
-      )}
-    </div>
-  );
-}
-
-function KeyModuleCard({ title, mod, children, onRefresh, refreshing = false }: {
-  title: string;
-  mod?: (ModuleStatusFields & { error?: string | null }) | null;
-  children: React.ReactNode;
-  onRefresh?: () => void;
-  refreshing?: boolean;
-}) {
-  if (!mod) return null;
-  const st = modStatus(mod);
-  if (st === 'ok') return <Card title={title} onRefresh={onRefresh} refreshing={refreshing}>{children}</Card>;
-  if (st === 'skipped' || st === 'rate_limited') {
-    return (
-      <Card title={title} extra={<ModuleStatusBadge status={st} />} onRefresh={onRefresh} refreshing={refreshing}>
-        <ModuleNotice status={st} reason={mod.status_reason} />
-      </Card>
-    );
-  }
-  return null;
-}
-
-function CopyIconButton({ onClick, label }: { onClick: () => void; label: string }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="text-text-3 hover:text-text-1 transition-colors p-0.5 rounded-sm hover:bg-surface-2"
-      title={label}
-      aria-label={label}
-    >
-      <Copy size={11} />
-    </button>
-  );
-}
-
-function FindingRow({ f }: { f: OpsecFinding }) {
-  const cls = f.severity === 'HIGH' ? 'badge badge-high' : f.severity === 'MEDIUM' ? 'badge badge-med' : 'badge badge-low';
-  return (
-    <div className="finding-row">
-      <span className={cls}>{f.severity}</span>
-      <div className="flex-1 min-w-0">
-        <div className="text-[12px] text-text-1">{f.message}</div>
-        <div className="text-[10px] text-text-3">−{f.deduction} pts · {f.category}</div>
-      </div>
-    </div>
-  );
-}
-
-const OPSEC_CATEGORY_INFO: Record<string, { label: string; tooltip: string }> = {
-  data_exposure: {
-    label: 'Data Exposure',
-    tooltip: 'Sensitive data leaks: breached credentials, exposed emails, public PII.',
-  },
-  identity_opsec: {
-    label: 'Identity OPSEC',
-    tooltip: 'Re-use of identifiers across platforms: same username/email across many sites.',
-  },
-  infrastructure: {
-    label: 'Infrastructure',
-    tooltip: 'Exposed services, open ports, weak DNS/WHOIS hygiene, threat-intel hits.',
-  },
-  web_security: {
-    label: 'Web Security',
-    tooltip: 'TLS, security headers, certificate transparency, archived sensitive paths.',
-  },
-};
-
-const TABS = [
-  { id: 'findings', label: 'Findings', icon: Shield },
-  { id: 'whois', label: 'WHOIS', icon: Globe },
-  { id: 'dns', label: 'DNS', icon: Server },
-  { id: 'subdomains', label: 'Subdomains', icon: Lock },
-  { id: 'accounts', label: 'Accounts', icon: User },
-  { id: 'github', label: 'GitHub', icon: Github },
-  { id: 'threats', label: 'Threats', icon: AlertTriangle },
-  { id: 'censys', label: 'Censys', icon: Eye },
-  { id: 'darkweb', label: 'Dark Web', icon: ShieldAlert },
-  { id: 'wayback', label: 'Wayback', icon: Clock },
-  { id: 'email', label: 'Email', icon: Mail },
-  { id: 'gravatar', label: 'Gravatar', icon: UserCircle },
-  { id: 'hudsonrock', label: 'Infostealers', icon: ShieldAlert },
-  { id: 'lunar', label: 'Exposure', icon: TrendingUp },
-  { id: 'dorks', label: 'Dorks', icon: Zap },
-  { id: 'phone', label: 'Phone', icon: Phone },
-  { id: 'telegram', label: 'Telegram', icon: MessageCircle },
-  { id: 'map', label: 'Map', icon: Map },
-  { id: 'graph', label: 'Graph', icon: GitBranch },
-  { id: 'json', label: 'JSON', icon: Code },
-  { id: 'ai', label: 'AI', icon: Brain },
-];
-
-interface Props { scan: ScanMeta & { results: ScanResults }; onHome: () => void; }
-
-export function ScanResults({ scan, onHome }: Props) {
-  const { t: i18n, locale } = useTranslations();
-  const [tab, setTab] = useState('findings');
-  const [aiSummary, setAiSummary] = useState('');
-  const [aiLoading, setAiLoading] = useState(false);
-  const [aiError, setAiError] = useState('');
-  const [aiModel, setAiModel] = useState('');
-  const [chatInput, setChatInput] = useState('');
-  const [chatHistory, setChatHistory] = useState<{role:'user'|'ai'; text:string}[]>([]);
-  const [chatLoading, setChatLoading] = useState(false);
-  const [showJson, setShowJson] = useState(false);
-  const [showBackToTop, setShowBackToTop] = useState(false);
-  const [copyToast, setCopyToast] = useState('');
-  const [reportLoading, setReportLoading] = useState<'html' | 'pdf' | null>(null);
-  const [localResults, setLocalResults] = useState<ScanResults>(scan.results);
-  const [refreshingModules, setRefreshingModules] = useState<Record<string, boolean>>({});
-  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  const r = localResults;
-  const opsec = r.opsec;
-
-  const showToast = (message: string) => {
-    setCopyToast(message);
-    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-    toastTimerRef.current = setTimeout(() => setCopyToast(''), 1200);
-  };
-
-  useEffect(() => {
-    setLocalResults(scan.results);
-    setRefreshingModules({});
-  }, [scan.id, scan.results]);
-
-  const isRefreshing = (module: string) => Boolean(refreshingModules[module]);
-
-  const refreshModule = async (module: string, keys: string[] = [module]) => {
-    if (isRefreshing(module)) return;
-    setRefreshingModules(prev => ({ ...prev, [module]: true }));
-    try {
-      const { scan_id } = await startScan(scan.target, scan.scan_type as ScanType, [module], true);
-      let done: { status: string; results: ScanResults; error?: string } | null = null;
-      for (let i = 0; i < 90; i += 1) {
-        await new Promise(res => setTimeout(res, 1500));
-        const d = await getScan(scan_id) as unknown as { status: string; results: ScanResults; error?: string };
-        if (d.status === 'completed') { done = d; break; }
-        if (d.status === 'failed' || d.status === 'error') throw new Error(d.error || 'Module refresh failed');
       }
-      if (!done) throw new Error('Module refresh timed out');
-      const src = done.results as unknown as Record<string, unknown>;
-      setLocalResults(prev => {
-        const next = { ...prev } as Record<string, unknown>;
-        for (const k of keys) if (k in src) next[k] = src[k];
-        return next as ScanResults;
-      });
-      showToast('Module refreshed');
-    } catch (e) {
-      showToast(e instanceof Error ? e.message : 'Module refresh failed');
-    } finally {
-      setRefreshingModules(prev => ({ ...prev, [module]: false }));
-    }
-  };
 
-  const copyValue = async (value: string | number | null | undefined) => {
-    const text = String(value ?? '').trim();
-    if (!text) return;
-    try {
-      await navigator.clipboard.writeText(text);
-      showToast('Copied!');
-    } catch {
-      showToast('Copy failed');
-    }
-  };
-
-  useEffect(() => () => {
-    if (toastTimerRef.current) clearTimeout(toastTimerRef.current);
-  }, []);
-
-  useEffect(() => {
-    const host = contentRef.current;
-    if (!host) return;
-    const onScroll = () => setShowBackToTop(host.scrollTop > 300);
-    onScroll();
-    host.addEventListener('scroll', onScroll, { passive: true });
-    return () => host.removeEventListener('scroll', onScroll as EventListener);
-  }, []);
-
-  const sendChat = async () => {
-    const msg = chatInput.trim();
-    if (!msg || chatLoading) return;
-    setChatInput('');
-    setChatHistory(prev => [...prev, { role: 'user', text: msg }]);
-    setChatLoading(true);
-    try {
-      const d = await sendAiChat(scan.id, msg);
-      setChatHistory(prev => [...prev, { role: 'ai', text: d.reply || d.error || 'No response' }]);
-    } catch (e) {
-      setChatHistory(prev => [...prev, { role: 'ai', text: e instanceof Error ? e.message : 'Error' }]);
-    }
-    setChatLoading(false);
-  };
-
-  const runAi = async () => {
-    setAiLoading(true); setAiError(''); setAiSummary('');
-    try {
-      const d = await generateAiSummary(scan.id);
-      if (d.error) setAiError(d.error);
-      else { setAiSummary(d.summary); setAiModel(d.model || ''); }
-    } catch (e: unknown) {
-      setAiError(e instanceof Error ? e.message : 'Unknown error');
-    } finally { setAiLoading(false); }
-  };
-
-  const openReport = async (format: 'html' | 'pdf') => {
-    if (reportLoading) return;
-    setReportLoading(format);
-    try {
-      const blob = await fetchReportBlob(scan.id, format, locale);
-      const url = URL.createObjectURL(blob);
-      const opened = window.open(url, '_blank', 'noopener,noreferrer');
-      if (!opened) {
-        const a = document.createElement('a');
-        a.href = url;
-        a.download = `prism-report-${scan.id}.${format === 'pdf' ? 'pdf' : 'html'}`;
-        document.body.appendChild(a);
-        a.click();
-        a.remove();
+      // Breach findings
+      if (key === 'breach' && value.found) {
+        const total = value.total || value.breaches?.length || 0;
+        items.push({
+          severity: total > 0 ? 'HIGH' : 'INFO',
+          message: `${total} breaches found${value.latest_breach ? ` (latest: ${value.latest_breach})` : ''}`,
+          source: 'Breach Check',
+        });
       }
-      setTimeout(() => URL.revokeObjectURL(url), 60_000);
-    } catch (e: unknown) {
-      showToast(e instanceof Error ? e.message : 'Report open failed');
-    } finally {
-      setReportLoading(null);
-    }
-  };
 
-  const downloadJson = () => {
-    try {
-      const blob = new Blob([JSON.stringify(scan.results, null, 2)], { type: 'application/json' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `prism-${filenameSegment(scan.target)}-${filenameSegment(scan.id)}.json`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
-    } catch (e: unknown) {
-      showToast(e instanceof Error ? e.message : 'JSON download failed');
-    }
-  };
+      // OPSEC score
+      if (key === 'opsec' && value.score !== undefined) {
+        const risk = value.risk_level || 'UNKNOWN';
+        const severity = risk === 'CRITICAL' ? 'CRITICAL' : 
+                        risk === 'HIGH' ? 'HIGH' :
+                        risk === 'MEDIUM' ? 'MEDIUM' : 'INFO';
+        items.push({
+          severity,
+          message: `OPSEC Score: ${value.score}/100 (${risk})`,
+          source: 'OPSEC',
+        });
+      }
 
-  const exportGraph = async (fmt: 'graphml' | 'gexf') => {
-    try {
-      const blob = await fetchGraphExport(scan.id, fmt);
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `prism-${filenameSegment(scan.target)}-${filenameSegment(scan.id)}.${fmt}`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
-    } catch (e: unknown) {
-      showToast(e instanceof Error ? e.message : 'Graph export failed');
-    }
-  };
+      // GeoIP
+      if (key === 'geoip' && value.country) {
+        items.push({
+          severity: 'INFO',
+          message: `Located in ${value.country}${value.city ? `, ${value.city}` : ''}`,
+          source: 'GeoIP',
+        });
+      }
 
-  const downloadCsv = () => {
-    try {
-      const rows: string[][] = [['Module', 'Key', 'Value']];
-      const flatten = (obj: unknown, prefix: string) => {
-        if (obj === null || obj === undefined) return;
-        if (Array.isArray(obj)) {
-          obj.forEach((item, i) => flatten(item, `${prefix}[${i}]`));
-        } else if (typeof obj === 'object') {
-          for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-            flatten(v, prefix ? `${prefix}.${k}` : k);
-          }
-        } else {
-          const parts = prefix.split('.');
-          const mod = parts[0] || '';
-          const key = parts.slice(1).join('.') || prefix;
-          const val = String(obj).replace(/"/g, '""');
-          rows.push([mod, key, `"${val}"`]);
+      // Certificate Transparency
+      if (key === 'cert_transparency' && value.subdomains?.length > 0) {
+        items.push({
+          severity: 'INFO',
+          message: `${value.subdomains.length} subdomains found via CT logs`,
+          source: 'CT Logs',
+        });
+      }
+
+      // WHOIS
+      if (key === 'whois' && value.registrar) {
+        items.push({
+          severity: 'INFO',
+          message: `Registered with ${value.registrar}${value.creation_date ? `, created ${value.creation_date}` : ''}`,
+          source: 'WHOIS',
+        });
+      }
+
+      // RDAP
+      if (key === 'rdap' && value.status === 'registered') {
+        let message = `Domain is registered`;
+        if (value.registrar) {
+          message += ` with ${value.registrar}`;
         }
-      };
-      flatten(scan.results, '');
-      const csv = rows.map(r => r.join(',')).join('\n');
-      const blob = new Blob(['\uFEFF' + csv], { type: 'text/csv;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `prism-${filenameSegment(scan.target)}-${filenameSegment(scan.id)}.csv`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
-    } catch (e: unknown) {
-      showToast(e instanceof Error ? e.message : 'CSV download failed');
-    }
-  };
-
-  const downloadMarkdown = () => {
-    try {
-      const lines: string[] = [];
-      lines.push(`# PRISM Scan Report`);
-      lines.push(`**Target:** ${scan.target}`);
-      lines.push(`**Type:** ${scan.scan_type}`);
-      if (scan.started_at) lines.push(`**Started:** ${scan.started_at.slice(0, 19).replace('T', ' ')}`);
-      if (scan.completed_at) lines.push(`**Completed:** ${scan.completed_at.slice(0, 19).replace('T', ' ')}`);
-      lines.push('');
-      if (opsec) {
-        lines.push(`## OPSEC Score: ${opsec.score}/100 (${opsec.risk_level})`);
-        for (const [k, cat] of Object.entries(opsec.categories)) {
-          lines.push(`- **${k.replace(/_/g, ' ')}:** ${cat.score}/${cat.max} (${cat.percent}%)`);
+        if (value.created) {
+          message += `, created ${value.created}`;
         }
-        lines.push('');
-      }
-      if (opsec?.all_findings?.length) {
-        lines.push('## Security Findings');
-        for (const f of opsec.all_findings) {
-          lines.push(`- [${f.severity}] ${f.message} (-${f.deduction} pts)`);
+        if (value.expires) {
+          message += `, expires ${value.expires}`;
         }
-        lines.push('');
-      }
-      if (r.whois && !r.whois.error) {
-        lines.push('## WHOIS');
-        if (r.whois.registrar) lines.push(`- Registrar: ${r.whois.registrar}`);
-        if (r.whois.org) lines.push(`- Organization: ${r.whois.org}`);
-        if (r.whois.country) lines.push(`- Country: ${r.whois.country}`);
-        if (r.whois.creation_date) lines.push(`- Created: ${r.whois.creation_date.slice(0, 10)}`);
-        lines.push('');
-      }
-      if (r.dns?.records) {
-        lines.push('## DNS Records');
-        for (const [type, recs] of Object.entries(r.dns.records)) {
-          if (Array.isArray(recs) && recs.length) {
-            lines.push(`### ${type}`);
-            recs.forEach(rec => lines.push(`- ${typeof rec === 'object' ? JSON.stringify(rec) : rec}`));
-          }
-        }
-        lines.push('');
-      }
-      if (r.cert_transparency?.subdomains?.length) {
-        lines.push(`## Subdomains (${r.cert_transparency.subdomains.length})`);
-        r.cert_transparency.subdomains.forEach(s => lines.push(`- ${s}`));
-        lines.push('');
-      }
-      const found = Array.isArray(r.blackbird) ? r.blackbird.filter(b => b.status === 'found') : [];
-      if (found.length) {
-        lines.push('## Accounts Found');
-        lines.push('| Platform | URL |');
-        lines.push('|----------|-----|');
-        found.forEach(b => lines.push(`| ${b.site} | ${b.url} |`));
-        lines.push('');
-      }
-      const md = lines.join('\n');
-      const blob = new Blob([md], { type: 'text/markdown;charset=utf-8' });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
-      a.href = url;
-      a.download = `prism-${filenameSegment(scan.target)}-${filenameSegment(scan.id)}.md`;
-      document.body.appendChild(a);
-      a.click();
-      a.remove();
-      setTimeout(() => URL.revokeObjectURL(url), 0);
-    } catch (e: unknown) {
-      showToast(e instanceof Error ? e.message : 'Markdown download failed');
-    }
-  };
-
-  const copyAsCurl = async () => {
-    const body = {
-      target: scan.target,
-      scan_type: scan.scan_type,
-      modules: scan.modules,
-      force_refresh: false,
-    };
-
-    const apiUrl = `${window.location.origin}/api/scan`;
-
-    const curl = [
-      `curl -X POST "${apiUrl}"`,
-      '-H "Content-Type: application/json"',
-      `-d '${JSON.stringify(body)}'`,
-    ].join(" \\\n");
-
-    await copyValue(curl);
-  };
-
-  const scanDuration = (() => {
-    if (!scan.started_at || !scan.completed_at) return null;
-    const ms = new Date(scan.completed_at).getTime() - new Date(scan.started_at).getTime();
-    if (ms < 0 || !Number.isFinite(ms)) return null;
-    if (ms < 1000) return `${ms}ms`;
-    const s = ms / 1000;
-    return s < 60 ? `${s.toFixed(1)}s` : `${Math.floor(s / 60)}m ${Math.round(s % 60)}s`;
-  })();
-
-  const allEmails = (() => {
-    const set = new Set<string>();
-    if (r.whois?.emails) r.whois.emails.forEach(e => set.add(e));
-    if (r.emailrep?.email) set.add(r.emailrep.email);
-    if (r.breaches?.breaches) {
-      for (const b of r.breaches.breaches) {
-        if (typeof b === 'string' && b.includes('@')) set.add(b);
-        if (typeof b === 'object' && b && 'email' in b) set.add((b as any).email);
+        items.push({
+          severity: 'INFO',
+          message,
+          source: 'RDAP',
+        });
       }
     }
-    // Scan target if it looks like email
-    if (scan.scan_type === 'email' && scan.target?.includes('@')) set.add(scan.target);
-    return Array.from(set);
-  })();
 
-  const copyAllEmails = async () => {
-    if (!allEmails.length) return;
-    try {
-      await navigator.clipboard.writeText(allEmails.join('\n'));
-      showToast(i18n('results.emailsCopied') || 'Emails copied!');
-    } catch {
-      showToast(i18n('common.copyFailed') || 'Copy failed');
-    }
+    // Sort by severity
+    items.sort((a, b) => {
+      const aIdx = SEVERITY_ORDER.indexOf(a.severity);
+      const bIdx = SEVERITY_ORDER.indexOf(b.severity);
+      return aIdx - bIdx;
+    });
+
+    return items;
+  }, [results]);
+
+  // OPSEC score
+  const opsec = results.opsec || {};
+  const score = opsec.score;
+  const riskLevel = opsec.risk_level || 'UNKNOWN';
+
+  // Get modules that ran
+  const modules = useMemo(() => {
+    return Object.entries(results)
+      .filter(([key, value]) => {
+        return key !== 'opsec' && key !== 'graph' && value !== null && value !== undefined;
+      })
+      .map(([key, value]) => ({ key, value }));
+  }, [results]);
+
+  // Download report
+  const downloadReport = async (format: string) => {
+    const apiBase = getPrismApiUrl();
+    const apiKey = getPrismApiKey();
+    const url = buildApiUrl(`/scan/${scanId}/report.${format}`, apiBase);
+    const response = await fetch(url, {
+      headers: apiKey ? { 'X-API-Key': apiKey } : {},
+    });
+    if (!response.ok) throw new Error('Failed to download report');
+    const blob = await response.blob();
+    const link = document.createElement('a');
+    link.href = URL.createObjectURL(blob);
+    link.download = `${target}_report.${format}`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(link.href);
   };
-
-  const [accountFilter, setAccountFilter] = useState('');
-
-  const accounts = Array.isArray(r.blackbird) ? r.blackbird : [];
-
-  const skippedIpProviders = [
-    { name: 'Shodan', mod: r.shodan, key: 'SHODAN_API_KEY' },
-    { name: 'VirusTotal', mod: r.virustotal, key: 'VIRUSTOTAL_API_KEY' },
-    { name: 'AbuseIPDB', mod: r.abuseipdb, key: 'ABUSEIPDB_API_KEY' },
-    { name: 'Censys', mod: r.censys, key: 'CENSYS_API_ID / CENSYS_API_SECRET' },
-  ].filter(({ mod }) => mod && modStatus(mod) === 'skipped');
-
-  const showLimitedIpNotice = scan.scan_type === 'ip' && skippedIpProviders.length > 0;
-
-  const visibleTabs = TABS.filter(t => {
-    if (t.id === 'whois') return r.whois && !r.whois.error;
-    if (t.id === 'dns') return r.dns?.records && Object.keys(r.dns.records).length > 0;
-    if (t.id === 'subdomains') return r.cert_transparency?.subdomains?.length;
-    if (t.id === 'accounts') return accounts.some(b => b.status === 'found');
-    if (t.id === 'github') return r.github && modStatus(r.github) === 'ok';
-    if (t.id === 'threats') return [r.virustotal, r.abuseipdb, r.shodan].some(m => m && modStatus(m) !== 'error');
-    if (t.id === 'censys') return r.censys && modStatus(r.censys) === 'ok';
-    if (t.id === 'darkweb') return r.onion && !r.onion.error && (r.onion.total_found ?? 0) > 0;
-    if (t.id === 'wayback') return r.wayback;
-    if (t.id === 'email') return r.emailrep || r.smtp || r.breaches || r.gravatar;
-    if (t.id === 'gravatar') return r.gravatar && modStatus(r.gravatar) === 'ok';
-    if (t.id === 'hudsonrock') return r.hudsonrock && modStatus(r.hudsonrock) === 'ok';
-    if (t.id === 'lunar') return r.lunar && modStatus(r.lunar) === 'ok';
-    if (t.id === 'dorks') return r.dorks?.length;
-    if (t.id === 'phone') return r.phone;
-    if (t.id === 'telegram') return r.telegram;
-    return true;
-  });
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const tag = (e.target as HTMLElement)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
-      if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
-        e.preventDefault();
-        const idx = visibleTabs.findIndex(t => t.id === tab);
-        if (idx === -1) return;
-        const next = e.key === 'ArrowRight'
-          ? (idx + 1) % visibleTabs.length
-          : (idx - 1 + visibleTabs.length) % visibleTabs.length;
-        setTab(visibleTabs[next].id);
-      }
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [tab, visibleTabs]);
 
   return (
-    <div className="flex flex-col h-[calc(100vh-48px)] animate-fade-in">
-      <div className="px-4 sm:px-5 py-3 border-b border-border-1 bg-surface-1 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
+    <div className="p-4 space-y-4 animate-fade-in">
+      {/* Header */}
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <div className="flex items-center gap-1.5">
-            <div className="font-bold text-text-1 text-[15px] break-all">{scan.target}</div>
-            <CopyIconButton onClick={() => copyValue(scan.target)} label="Copy target" />
-          </div>
-          <div className="flex items-center gap-2 mt-0.5 flex-wrap">
-            <span className="badge badge-info">{scan.scan_type?.toUpperCase()}</span>
-            {scan.started_at && (
-              <span className="text-[10px] text-text-3 hidden sm:inline">{scan.started_at.slice(0, 19).replace('T', ' ')}</span>
-            )}
-            {scanDuration && (
-              <span className="text-[10px] text-green font-medium">{i18n('results.duration').replace('{duration}', scanDuration) !== `results.duration` ? i18n('results.duration').replace('{duration}', scanDuration) : `Completed in ${scanDuration}`}</span>
-            )}
-          </div>
+          <h1 className="text-2xl font-bold text-text-1">{target}</h1>
+          <p className="text-sm text-text-3">
+            {t('scan.type')}: {scanType.toUpperCase()} · {t('scan.completed')}
+          </p>
         </div>
-        <div className="flex flex-wrap gap-2 sm:justify-end">
-          <button type="button" onClick={onHome}
-            className="btn-ghost text-[11px] h-8 px-3">
-            <Search size={11} /> {i18n('results.scanAnother')}
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => downloadReport('html')}
+            className="btn-secondary text-sm flex items-center gap-1"
+          >
+            <FileText size={16} />
+            HTML
           </button>
-          <button type="button" onClick={() => openReport('html')} disabled={reportLoading !== null}
-            className="btn-ghost text-[11px] h-8 px-3">
-            {reportLoading === 'html' ? '...' : <ExternalLink size={11} />} {i18n('results.htmlReport')}
+          <button
+            onClick={() => downloadReport('pdf')}
+            className="btn-secondary text-sm flex items-center gap-1"
+          >
+            <FileText size={16} />
+            PDF
           </button>
-          <button type="button" onClick={() => openReport('pdf')} disabled={reportLoading !== null}
-            className="btn-ghost text-[11px] h-8 px-3">
-            {reportLoading === 'pdf' ? '...' : <Printer size={11} />} {i18n('results.pdfReport')}
+          <button
+            onClick={() => downloadReport('json')}
+            className="btn-secondary text-sm flex items-center gap-1"
+          >
+            <Code size={16} />
+            JSON
           </button>
-          <button type="button" onClick={downloadJson}
-            className="btn-ghost text-[11px] h-8 px-3">
-            <Download size={11} /> {i18n('results.jsonReport')}
+          <button
+            onClick={() => setShowRaw(!showRaw)}
+            className="btn-secondary text-sm flex items-center gap-1"
+          >
+            {showRaw ? <EyeOff size={16} /> : <Eye size={16} />}
+            {showRaw ? 'Hide Raw' : 'Raw'}
           </button>
-          <button type="button" onClick={downloadCsv}
-            className="btn-ghost text-[11px] h-8 px-3">
-            <FileSpreadsheet size={11} /> {i18n('results.csvReport') !== 'results.csvReport' ? i18n('results.csvReport') : 'CSV'}
-          </button>
-          <button type="button" onClick={downloadMarkdown}
-            className="btn-ghost text-[11px] h-8 px-3">
-            <FileText size={11} /> {i18n('results.mdReport') !== 'results.mdReport' ? i18n('results.mdReport') : 'Markdown'}
-          </button>
-          <button type="button" onClick={copyAsCurl}
-            className="btn-ghost text-[11px] h-8 px-3">
-            <Copy size={11} /> {i18n('results.copyCurl') !== 'results.copyCurl' ? i18n('results.copyCurl') : 'cURL'}
-          </button>
-          {allEmails.length >= 2 && (
-            <button type="button" onClick={copyAllEmails}
-              className="btn-ghost text-[11px] h-8 px-3">
-              <Mail size={11} /> {i18n('results.copyAllEmails') !== 'results.copyAllEmails' ? i18n('results.copyAllEmails') : 'Copy emails'}
-            </button>
-          )}
         </div>
       </div>
 
-      {showLimitedIpNotice && (
-        <div className="px-4 sm:px-5 py-3 border-b border-border-1 bg-yellow/5">
-          <div className="flex items-start gap-2.5 max-w-5xl">
-            <AlertTriangle size={15} className="text-yellow mt-0.5 shrink-0" />
-            <div className="min-w-0">
-              <div className="text-[12px] font-semibold text-text-1">
-                IP scan completed with limited provider data
-              </div>
-              <div className="text-[11px] text-text-2 mt-0.5 leading-relaxed">
-                {skippedIpProviders.map(p => p.name).join(', ')} skipped because provider keys are missing. Add{' '}
-                <code className="font-mono text-text-1">
-                  {skippedIpProviders.map(p => p.key).join(', ')}
-                </code>{' '}
-                to <code className="font-mono text-text-1">.env</code> and recreate the container for deeper IP intelligence.
+      {/* OPSEC Score */}
+      {score !== undefined && (
+        <div className="card">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <Shield size={24} className={`
+                ${score >= 70 ? 'text-green' : score >= 40 ? 'text-yellow' : 'text-red'}
+              `} />
+              <div>
+                <div className="text-sm font-semibold text-text-1">{t('opsec.title')}</div>
+                <div className="text-sm text-text-3">{t('opsec.risk')}: {riskLevel}</div>
               </div>
             </div>
+            <div className="text-right">
+              <div className={`
+                text-3xl font-bold
+                ${score >= 70 ? 'text-green' : score >= 40 ? 'text-yellow' : 'text-red'}
+              `}>
+                {score}/100
+              </div>
+              <div className="text-xs text-text-3">{t('opsec.label')}</div>
+            </div>
+          </div>
+          <div className="mt-3 w-full h-2 bg-surface-2 rounded-full overflow-hidden">
+            <div
+              className="h-full transition-all duration-500"
+              style={{
+                width: `${score}%`,
+                background: `linear-gradient(90deg, 
+                  ${score <= 30 ? '#ef4444' : score <= 60 ? '#eab308' : '#22c55e'}
+                )`,
+              }}
+            />
           </div>
         </div>
       )}
 
-      {opsec && (
-        <div className="px-4 sm:px-5 py-2.5 bg-surface-2 border-b border-border-1 flex items-center gap-4 sm:gap-6 overflow-x-auto scrollbar-hide">
-          <div className="flex items-center gap-3">
-            <div className="text-3xl font-black" style={{ color: RISK_COLOR[opsec.risk_level] }}>
-              {opsec.score}
-            </div>
-            <div>
-              <div className="text-[10px] text-text-3">OPSEC Score</div>
-              <div className="text-[11px] font-bold" style={{ color: RISK_COLOR[opsec.risk_level] }}>
-                {opsec.risk_level} RISK
-              </div>
-            </div>
+      {/* Findings */}
+      {findings.length > 0 && (
+        <div className="card">
+          <div className="card-head">
+            <AlertTriangle size={16} />
+            {t('findings.title')}
           </div>
-          {Object.entries(opsec.categories).map(([k, cat]) => {
-            const info = OPSEC_CATEGORY_INFO[k];
-            const label = info?.label ?? k.replace(/_/g, ' ');
-            const tooltip = info?.tooltip ?? '';
-            return (
-              <div key={k} className="flex items-center gap-2" title={tooltip}>
-                <div className="text-[10px] text-text-3 capitalize flex items-center gap-1 cursor-help">
-                  {label}
-                  {tooltip && <span aria-hidden className="opacity-60">ⓘ</span>}
+          <div className="p-3 space-y-1.5">
+            {findings.map((finding, i) => (
+              <div key={i} className="flex items-start gap-2 text-sm">
+                <span className={`
+                  inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-semibold whitespace-nowrap
+                  ${finding.severity === 'CRITICAL' || finding.severity === 'HIGH' ? 'bg-red/10 text-red' :
+                    finding.severity === 'MEDIUM' ? 'bg-yellow/10 text-yellow' :
+                    'bg-blue/10 text-blue'}
+                `}>
+                  {finding.severity}
+                </span>
+                <span className="text-text-2">{finding.message}</span>
+                <span className="text-xs text-text-3 ml-auto">[{finding.source}]</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Module Results */}
+      <div className="space-y-2">
+        {modules.map(({ key, value }) => {
+          const moduleInfo = MODULE_MAP[key];
+          const label = moduleInfo?.label || key;
+          const icon = moduleInfo?.icon || '📦';
+          const isExpanded = expandedModules.has(key);
+          const hasData = value && typeof value === 'object' && Object.keys(value).length > 0;
+          const isError = value?.error;
+          const status = value?.status || (isError ? 'error' : 'ok');
+
+          if (!hasData && !isError) return null;
+
+          return (
+            <div key={key} className="card overflow-hidden">
+              <button
+                onClick={() => toggleModule(key)}
+                className="w-full flex items-center gap-2 p-3 hover:bg-surface-2/50 transition-colors"
+              >
+                <span className="text-base">{icon}</span>
+                <span className="font-medium text-text-1">{label}</span>
+                <span className={`
+                  text-xs px-2 py-0.5 rounded ml-auto
+                  ${status === 'ok' ? 'bg-green/10 text-green' :
+                    status === 'skipped' ? 'bg-text-3/10 text-text-3' :
+                    status === 'rate_limited' ? 'bg-yellow/10 text-yellow' :
+                    'bg-red/10 text-red'}
+                `}>
+                  {status}
+                </span>
+                {isExpanded ? <ChevronDown size={16} className="text-text-3" /> : <ChevronRight size={16} className="text-text-3" />}
+              </button>
+
+              {isExpanded && (
+                <div className="p-3 pt-0 border-t border-border-1">
+                  {isError ? (
+                    <div className="text-red text-sm">{value.error}</div>
+                  ) : (
+                    <ModuleData data={value} />
+                  )}
                 </div>
-                <div className="w-20 h-1.5 rounded-full bg-surface-3 overflow-hidden">
-                  <div className="h-full rounded-full" style={{ width: `${cat.percent}%`, background: cat.percent > 60 ? '#3fb950' : cat.percent > 30 ? '#d29922' : '#f85149' }} />
-                </div>
-                <div className="text-[10px] font-mono text-text-2">{cat.score}/{cat.max}</div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Raw JSON */}
+      {showRaw && (
+        <div className="card">
+          <div className="card-head">
+            <Code size={16} />
+            Raw Data
+          </div>
+          <pre className="p-3 bg-surface-2 rounded text-xs font-mono overflow-auto max-h-96 text-text-2">
+            {JSON.stringify(results, null, 2)}
+          </pre>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ModuleData({ data }: { data: any }) {
+  if (!data || typeof data !== 'object') {
+    return <div className="text-text-3 text-sm">{String(data)}</div>;
+  }
+
+  // Skip internal fields
+  const skipFields = ['status', 'status_reason', 'error'];
+
+  const entries = Object.entries(data).filter(([k]) => !skipFields.includes(k));
+
+  if (entries.length === 0) {
+    return <div className="text-text-3 text-sm">No data</div>;
+  }
+
+  return (
+    <div className="space-y-2 text-sm">
+      {entries.map(([key, value]) => {
+        if (value === null || value === undefined) return null;
+        if (typeof value === 'string' && !value) return null;
+
+        let display: React.ReactNode;
+
+        if (Array.isArray(value)) {
+          if (value.length === 0) {
+            display = <span className="text-text-3">Empty</span>;
+          } else if (typeof value[0] === 'string') {
+            display = (
+              <div className="flex flex-wrap gap-1">
+                {value.map((item, i) => (
+                  <span key={i} className="tag">{item}</span>
+                ))}
               </div>
             );
-          })}
-        </div>
-      )}
+          } else {
+            display = (
+              <div className="space-y-1">
+                {value.map((item, i) => (
+                  <div key={i} className="p-2 bg-surface-2 rounded text-xs">
+                    <ModuleData data={item} />
+                  </div>
+                ))}
+              </div>
+            );
+          }
+        } else if (typeof value === 'object') {
+          display = <ModuleData data={value} />;
+        } else if (typeof value === 'boolean') {
+          display = value ? <Check size={14} className="text-green" /> : <X size={14} className="text-red" />;
+        } else {
+          display = <span className="font-mono text-text-1">{String(value)}</span>;
+        }
 
-      <div className="border-b border-border-1 bg-surface-1 flex overflow-x-auto scrollbar-hide">
-        {visibleTabs.map(({ id, label, icon: Icon }) => (
-          <button key={id} onClick={() => setTab(id)}
-            className={`tab-btn ${tab === id ? 'active' : ''}`}>
-            <Icon size={11} />{i18n(`results.tabs.${id}`) === `results.tabs.${id}` ? label : i18n(`results.tabs.${id}`)}
-          </button>
-        ))}
-      </div>
-
-      <div ref={contentRef} className={`flex-1 overflow-y-auto p-5 ${showBackToTop ? 'pb-24' : ''}`}>
-
-        {tab === 'findings' && (
-          <div>
-            {opsec?.all_findings?.length ? (
-              <Card title="Security Findings">
-                {opsec.all_findings.map((f, i) => <FindingRow key={i} f={f} />)}
-              </Card>
-            ) : (
-              <div className="card p-6 text-center text-text-3 text-sm">No security findings</div>
-            )}
+        return (
+          <div key={key} className="flex items-start gap-2 border-b border-border-1/50 py-1.5 last:border-0">
+            <span className="text-text-3 text-xs font-mono whitespace-nowrap min-w-[100px]">{key}</span>
+            <div className="flex-1 min-w-0">{display}</div>
           </div>
-        )}
-
-        {tab === 'whois' && r.whois && (
-          <Card title="WHOIS Registration" onRefresh={() => refreshModule('whois')} refreshing={isRefreshing('whois')}>
-            <div className="space-y-1.5">
-              <DtRow label="Registrar" value={r.whois.registrar} />
-              <DtRow label="Organization" value={r.whois.org} />
-              <DtRow label="Country" value={r.whois.country} />
-              <DtRow label="Created" value={r.whois.creation_date?.slice(0, 10)} />
-              <DtRow label="Expires" value={r.whois.expiration_date?.slice(0, 10)} />
-              {r.whois.emails?.length && (
-                <div className="dt-row"><span className="dt-label">Emails</span>
-                  <div className="flex flex-wrap gap-1">
-                    {r.whois.emails.map(e => (
-                      <span key={e} className="inline-flex items-center gap-1">
-                        <span className="tag tag-red">{e}</span>
-                        <CopyIconButton onClick={() => copyValue(e)} label="Copy email" />
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {r.whois.name_servers?.length && (
-                <div className="dt-row"><span className="dt-label">Name Servers</span>
-                  <div className="flex flex-wrap gap-1">
-                    {r.whois.name_servers.slice(0, 4).map(ns => (
-                      <span key={ns} className="inline-flex items-center gap-1">
-                        <span className="tag">{ns}</span>
-                        <CopyIconButton onClick={() => copyValue(ns)} label="Copy domain" />
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          </Card>
-        )}
-
-        {tab === 'dns' && r.dns?.records && (
-          <Card title="DNS Records" onRefresh={() => refreshModule('dns')} refreshing={isRefreshing('dns')}>
-            {Object.entries(r.dns.records).filter(([, v]) => Array.isArray(v) && v.length > 0).length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-10 text-center">
-                <Server size={24} className="text-text-3 opacity-40 mb-2" />
-                <div className="text-text-3 text-sm">No DNS records found</div>
-              </div>
-            ) : (
-              Object.entries(r.dns.records).filter(([, v]) => Array.isArray(v) && v.length > 0).map(([type, records]) => (
-                <div key={type} className="mb-4">
-                  <div className="text-[11px] font-bold text-blue mb-1.5 uppercase tracking-wider">{type}</div>
-                  {(records as unknown[]).map((rec, i) => {
-                    const text = typeof rec === 'object' ? JSON.stringify(rec) : String(rec);
-                    return (
-                      <div key={i} className="flex items-center gap-1.5 py-0.5">
-                        <div className="font-mono text-[11px] text-text-2 break-all flex-1">{text}</div>
-                        <CopyIconButton onClick={() => copyValue(text)} label="Copy DNS record" />
-                      </div>
-                    );
-                  })}
-                </div>
-              ))
-            )}
-          </Card>
-        )}
-
-        {tab === 'subdomains' && r.cert_transparency && (
-          <Card title={`Certificate Transparency - ${r.cert_transparency.subdomains?.length} subdomains`} onRefresh={() => refreshModule('cert_transparency')} refreshing={isRefreshing('cert_transparency')}>
-            <div className="text-[11px] text-text-3 mb-3">{r.cert_transparency.total_certs} certificate(s) analysed</div>
-            <div className="flex flex-wrap gap-1">
-              {r.cert_transparency.subdomains?.map(s => (
-                <span key={s} className="inline-flex items-center gap-1">
-                  <span className="tag">{s}</span>
-                  <CopyIconButton onClick={() => copyValue(s)} label="Copy subdomain" />
-                </span>
-              ))}
-            </div>
-          </Card>
-        )}
-
-        {tab === 'accounts' && (
-          <Card title="Username Search" onRefresh={() => refreshModule('blackbird')} refreshing={isRefreshing('blackbird')}>
-            <div className="text-[11px] text-text-3 leading-relaxed mb-3">
-              {"Heuristic matches from profile-page responses - false positives are possible on sites that serve a page for any username. Open each link to confirm before relying on it."}
-            </div>
-            <div className="mb-3">
-              <div className="relative">
-                <Search size={13} className="absolute left-3 top-1/2 -translate-y-1/2 text-text-3" />
-                <input
-                  type="text"
-                  value={accountFilter}
-                  onChange={e => setAccountFilter(e.target.value)}
-                  placeholder={i18n('results.filterPlatforms') !== 'results.filterPlatforms' ? i18n('results.filterPlatforms') : 'Filter platforms...'}
-                  className="input-field w-full pl-9 text-[12px] h-9"
-                />
-              </div>
-            </div>
-            <div className="overflow-x-auto -mx-4 px-4">
-            <table className="w-full text-[12px] min-w-[400px]">
-              <thead><tr className="text-left text-text-3 text-[10px] uppercase tracking-wider border-b border-border-1">
-                <th className="pb-2">Platform</th><th className="pb-2">URL</th><th className="pb-2 text-right">Time</th>
-              </tr></thead>
-              <tbody>{accounts.filter(b => b.status === 'found' && (!accountFilter || b.site.toLowerCase().includes(accountFilter.toLowerCase()))).map(b => (
-                <tr key={b.site} className="border-b border-border-1 last:border-0">
-                  <td className="py-2 font-medium text-text-1">{b.site}</td>
-                  <td className="py-2">
-                    <div className="flex items-center gap-1.5">
-                      <a href={b.url} target="_blank" rel="noreferrer" className="text-blue hover:underline truncate block max-w-xs">{b.url}</a>
-                      <CopyIconButton onClick={() => copyValue(b.url)} label="Copy username URL" />
-                    </div>
-                  </td>
-                  <td className="py-2 text-right font-mono text-text-3">{b.response_time?.toFixed(2)}s</td>
-                </tr>
-              ))}</tbody>
-            </table>
-            </div>
-            {(accounts.filter(b => b.status === 'found' && (!accountFilter || b.site.toLowerCase().includes(accountFilter.toLowerCase()))).length === 0) && (
-              <div className="flex flex-col items-center justify-center py-10 text-center">
-                <User size={24} className="text-text-3 opacity-40 mb-2" />
-                <div className="text-text-3 text-sm">
-                  {accountFilter ? 'No platforms match your filter' : 'No accounts found'}
-                </div>
-              </div>
-            )}
-          </Card>
-        )}
-
-        {tab === 'github' && (
-          <KeyModuleCard title="GitHub Recon" mod={r.github} onRefresh={() => refreshModule('github')} refreshing={isRefreshing('github')}>
-            <div className="space-y-1.5">
-              {r.github?.profile?.html_url && (
-                <div className="dt-row"><span className="dt-label">Profile</span>
-                  <a href={r.github.profile.html_url} target="_blank" rel="noreferrer" className="text-blue hover:underline">{r.github.profile.html_url}</a>
-                </div>
-              )}
-              <DtRow label="Name" value={r.github?.profile?.name} />
-              <DtRow label="Type" value={r.github?.profile?.type} />
-              <DtRow label="Bio" value={r.github?.profile?.bio} />
-              <DtRow label="Company" value={r.github?.profile?.company} />
-              <DtRow label="Location" value={r.github?.profile?.location} />
-              <DtRow label="Blog" value={r.github?.profile?.blog} />
-              <DtRow label="Twitter" value={r.github?.profile?.twitter} />
-              <DtRow label="Followers" value={r.github?.profile?.followers} />
-              <DtRow label="Public Repos" value={r.github?.profile?.public_repos} />
-              <DtRow label="Total Stars" value={r.github?.total_stars} />
-              <DtRow label="Joined" value={r.github?.profile?.created_at} />
-            </div>
-            {(r.github?.top_languages?.length ?? 0) > 0 && (
-              <div className="mt-3">
-                <div className="text-[10px] text-text-3 uppercase tracking-wider mb-2">Top Languages</div>
-                <div className="flex flex-wrap gap-1">
-                  {r.github?.top_languages?.map(l => (
-                    <span key={l.language} className="tag tag-blue">{l.language} ({l.count})</span>
-                  ))}
-                </div>
-              </div>
-            )}
-            {(r.github?.emails?.length ?? 0) > 0 && (
-              <div className="mt-3">
-                <div className="text-[10px] text-text-3 uppercase tracking-wider mb-2">Emails Found</div>
-                <div className="flex flex-wrap gap-1">
-                  {r.github?.emails?.map(e => (
-                    <span key={e} className="inline-flex items-center gap-1">
-                      <span className="tag tag-red">{e}</span>
-                      <CopyIconButton onClick={() => copyValue(e)} label="Copy email" />
-                    </span>
-                  ))}
-                </div>
-              </div>
-            )}
-          </KeyModuleCard>
-        )}
-
-        {tab === 'threats' && (
-          <div>
-            <KeyModuleCard title="VirusTotal" mod={r.virustotal} onRefresh={() => refreshModule('virustotal')} refreshing={isRefreshing('virustotal')}>
-              {!r.virustotal?.malicious && !r.virustotal?.suspicious && !r.virustotal?.harmless && !r.virustotal?.undetected ? (
-                <div className="text-text-3 text-sm py-2">No threats detected</div>
-              ) : (
-                <>
-                  <div className="grid grid-cols-2 sm:flex sm:gap-6 mb-4 gap-3">
-                    {[['Malicious', r.virustotal?.malicious, '#f85149'], ['Suspicious', r.virustotal?.suspicious, '#d29922'], ['Harmless', r.virustotal?.harmless, '#3fb950'], ['Undetected', r.virustotal?.undetected, '#484f58']].map(([l, v, c]) => (
-                      <div key={String(l)} className="text-center">
-                        <div className="text-2xl font-black" style={{ color: String(c) }}>{v}</div>
-                        <div className="text-[10px] text-text-3">{l}</div>
-                      </div>
-                    ))}
-                  </div>
-                  <div className="space-y-1.5">
-                    <DtRow label="Country" value={r.virustotal?.country} />
-                    <DtRow label="ASN" value={r.virustotal?.as_owner} />
-                  </div>
-                </>
-              )}
-            </KeyModuleCard>
-            <KeyModuleCard title="AbuseIPDB" mod={r.abuseipdb} onRefresh={() => refreshModule('abuseipdb')} refreshing={isRefreshing('abuseipdb')}>
-              {!r.abuseipdb?.abuse_score && !r.abuseipdb?.total_reports && !r.abuseipdb?.isp && !r.abuseipdb?.usage_type ? (
-                <div className="text-text-3 text-sm py-2">No threats detected</div>
-              ) : (
-                <div className="space-y-1.5">
-                  <div className="dt-row"><span className="dt-label">Abuse Score</span>
-                    <span className="font-black" style={{ color: (r.abuseipdb?.abuse_score ?? 0) >= 50 ? '#f85149' : (r.abuseipdb?.abuse_score ?? 0) >= 10 ? '#d29922' : '#3fb950' }}>
-                      {r.abuseipdb?.abuse_score}/100
-                    </span>
-                  </div>
-                  <DtRow label="Total Reports" value={r.abuseipdb?.total_reports} />
-                  <DtRow label="ISP" value={r.abuseipdb?.isp} />
-                  <DtRow label="Usage Type" value={r.abuseipdb?.usage_type} />
-                  {r.abuseipdb?.is_tor && <div className="text-red text-[12px] font-semibold mt-1">⚠ TOR Exit Node</div>}
-                </div>
-              )}
-            </KeyModuleCard>
-            <KeyModuleCard title="Shodan" mod={r.shodan} onRefresh={() => refreshModule('shodan')} refreshing={isRefreshing('shodan')}>
-              {r.shodan?.source === 'internetdb' && (
-                <div className="text-[11px] text-text-3 leading-relaxed mb-3 pb-2 border-b border-border-1">
-                  {"Ports, hostnames and CVEs below come from InternetDB, Shodan's free dataset. It carries no organisation, location or service banners — a paid Shodan key fills those in."}
-                </div>
-              )}
-              {r.shodan?.open_ports?.length ? (
-                <div className="mb-3">
-                  <div className="text-[10px] text-text-3 uppercase tracking-wider mb-2">Open Ports</div>
-                  {r.shodan.open_ports.map(p => (
-                    <span key={p} className="inline-flex items-center gap-1 mr-1">
-                      <span className={`tag ${[21,22,23,3389,5900,445,3306,5432,27017,6379].includes(p) ? 'tag-red' : ''}`}>{p}</span>
-                      <CopyIconButton onClick={() => copyValue(p)} label="Copy Shodan port" />
-                    </span>
-                  ))}
-                </div>
-              ) : null}
-              {r.shodan?.vulns?.length ? (
-                <div className="mb-3">
-                  <div className="text-[10px] text-text-3 uppercase tracking-wider mb-2 text-red">CVEs Found</div>
-                  {r.shodan.vulns.map(v => <span key={v} className="tag tag-red">{v}</span>)}
-                </div>
-              ) : null}
-              {!r.shodan?.open_ports?.length && !r.shodan?.vulns?.length && (
-                <div className="text-text-3 text-sm py-2">No threats detected</div>
-              )}
-            </KeyModuleCard>
-          </div>
-        )}
-
-        {tab === 'censys' && (
-          <KeyModuleCard title={`Censys - ${r.censys?.domain ? 'Certificate Search' : 'Host Info'}`} mod={r.censys} onRefresh={() => refreshModule('censys')} refreshing={isRefreshing('censys')}>
-            <div className="space-y-1.5">
-              {r.censys?.ip && <div className="dt-row"><span className="dt-label">IP</span><span className="dt-value">{r.censys.ip}</span></div>}
-              {r.censys?.asn && <div className="dt-row"><span className="dt-label">ASN</span><span className="dt-value">AS{r.censys.asn} {r.censys.as_name ?? ''}</span></div>}
-              {r.censys?.country && <div className="dt-row"><span className="dt-label">Location</span><span className="dt-value">{[r.censys.city, r.censys.country].filter(Boolean).join(', ')}</span></div>}
-              {r.censys?.open_ports && r.censys.open_ports.length > 0 && (
-                <div className="dt-row"><span className="dt-label">Open Ports</span>
-                  <div className="flex flex-wrap gap-1">
-                    {r.censys.open_ports.map(p => (
-                      <span key={p} className="inline-flex items-center gap-1">
-                        <span className="tag">{p}</span>
-                        <CopyIconButton onClick={() => copyValue(p)} label="Copy port" />
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {r.censys?.subdomains && r.censys.subdomains.length > 0 && (
-                <div className="dt-row"><span className="dt-label">Subdomains ({r.censys.subdomains.length})</span>
-                  <div className="flex flex-wrap gap-1">
-                    {r.censys.subdomains.map(s => (
-                      <span key={s} className="inline-flex items-center gap-1">
-                        <span className="tag tag-blue">{s}</span>
-                        <CopyIconButton onClick={() => copyValue(s)} label="Copy subdomain" />
-                      </span>
-                    ))}
-                  </div>
-                </div>
-              )}
-              {r.censys?.services && r.censys.services.length > 0 && (
-                <div className="mt-3">
-                  <div className="text-[10px] text-text-3 uppercase tracking-wider mb-2">Services</div>
-                  <table className="w-full text-[12px]">
-                    <thead><tr className="text-left text-text-3 text-[10px] uppercase tracking-wider border-b border-border-1">
-                      <th className="pb-2">Port</th><th className="pb-2">Service</th><th className="pb-2">Software</th>
-                    </tr></thead>
-                    <tbody>{r.censys.services.map((s, i) => (
-                      <tr key={i} className="border-b border-border-1 last:border-0">
-                        <td className="py-1.5 font-mono">{s.port}/{s.transport ?? 'tcp'}</td>
-                        <td className="py-1.5">{s.service ?? '-'}</td>
-                        <td className="py-1.5 text-text-3">{s.software ?? '-'}</td>
-                      </tr>
-                    ))}</tbody>
-                  </table>
-                </div>
-              )}
-            </div>
-          </KeyModuleCard>
-        )}
-
-        {tab === 'darkweb' && r.onion && (
-          <Card title={`Dark Web Mirrors - ${r.onion.total_found} found`} onRefresh={() => refreshModule('onion')} refreshing={isRefreshing('onion')}>
-            <div className="text-[11px] text-text-3 mb-3">
-              Sources: Ahmia ({r.onion.sources?.ahmia ?? 0}) · DarkSearch ({r.onion.sources?.darksearch ?? 0})
-            </div>
-            <div className="space-y-2">
-              {r.onion.results?.map((item, i) => (
-                <div key={i} className="border border-border-1 rounded p-2.5 bg-surface-2">
-                  <div className="flex items-center gap-1.5">
-                    <span className="text-[10px] tag tag-red uppercase">{item.source}</span>
-                    <span className="font-mono text-[11px] text-text-1 break-all flex-1">{item.url}</span>
-                    <CopyIconButton onClick={() => copyValue(item.url)} label="Copy onion URL" />
-                  </div>
-                  {item.title && <div className="text-[12px] text-text-2 mt-1.5">{item.title}</div>}
-                  {item.description && <div className="text-[11px] text-text-3 mt-0.5">{item.description}</div>}
-                </div>
-              ))}
-            </div>
-          </Card>
-        )}
-
-        {tab === 'wayback' && r.wayback && (
-          <Card title="Wayback Machine" onRefresh={() => refreshModule('wayback')} refreshing={isRefreshing('wayback')}>
-            {!r.wayback.snapshots?.length && !r.wayback.interesting?.length ? (
-              <div className="flex flex-col items-center justify-center py-10 text-center">
-                <Clock size={24} className="text-text-3 opacity-40 mb-2" />
-                <div className="text-text-3 text-sm">No archived snapshots found</div>
-              </div>
-            ) : (
-              <>
-                {r.wayback.total_snapshots && (
-                  <div className="text-[12px] text-text-2 mb-4">
-                    {r.wayback.total_snapshots} snapshots · First: {r.wayback.first_snapshot} · Last: {r.wayback.last_snapshot}
-                  </div>
-                )}
-                {r.wayback.snapshots?.length && (
-                  <div className="mb-4">
-                    <div className="text-[11px] font-semibold text-blue mb-2">Recent Snapshots</div>
-                    <div className="space-y-1">
-                      {r.wayback.snapshots.slice(0, 10).map(s => (
-                        <div key={s.timestamp} className="flex items-center gap-2 text-[10px]">
-                          <span className="text-text-3 font-mono">{s.date}</span>
-                          <a href={s.wayback_url} target="_blank" rel="noreferrer" className="text-blue hover:underline truncate flex-1">
-                            {s.wayback_url}
-                          </a>
-                          <span className="text-text-3">{s.mime}</span>
-                          {s.size > 0 && <span className="text-text-3">{Math.round(s.size/1024)}KB</span>}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {r.wayback.interesting?.length && (
-                  <div>
-                    <div className="text-[11px] font-semibold text-red mb-2">Sensitive URLs in Archive</div>
-                    {r.wayback.interesting.slice(0, 15).map(url => (
-                      <div key={url} className="font-mono text-[10px] text-text-2 py-0.5 truncate">
-                        <a href={url} target="_blank" rel="noreferrer" className="hover:text-blue">{url}</a>
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </>
-            )}
-          </Card>
-        )}
-
-        {tab === 'email' && (
-          <div>
-            {r.emailrep && !r.emailrep.error && (
-              <Card title="Email Reputation" onRefresh={() => refreshModule('emailrep')} refreshing={isRefreshing('emailrep')}>
-                <div className="space-y-1.5">
-                  <div className="dt-row"><span className="dt-label">Reputation</span>
-                    <span className={`font-bold ${r.emailrep.reputation === 'high' ? 'text-green' : r.emailrep.reputation === 'medium' ? 'text-yellow' : 'text-red'}`}>
-                      {(r.emailrep.reputation || 'N/A').toUpperCase()}
-                    </span>
-                  </div>
-                  <div className="dt-row"><span className="dt-label">Suspicious</span>
-                    <span className={r.emailrep.suspicious ? 'text-red' : 'text-green'}>{r.emailrep.suspicious ? 'Yes' : 'No'}</span>
-                  </div>
-                  <div className="dt-row"><span className="dt-label">Valid MX</span>
-                    <span className={r.emailrep.valid_mx ? 'text-green' : 'text-red'}>{r.emailrep.valid_mx ? 'Yes' : 'No'}</span>
-                  </div>
-                  <div className="dt-row"><span className="dt-label">Deliverable</span>
-                    <span className={r.emailrep.deliverable ? 'text-green' : r.emailrep.deliverable === false ? 'text-red' : 'text-text-3'}>
-                      {r.emailrep.deliverable === true ? 'Yes' : r.emailrep.deliverable === false ? 'No' : 'Unknown'}
-                    </span>
-                  </div>
-                  <div className="dt-row"><span className="dt-label">SPF</span>
-                    <span className={r.emailrep.spf ? 'text-green' : 'text-red'}>{r.emailrep.spf ? 'Yes' : 'No'}</span>
-                  </div>
-                  <div className="dt-row"><span className="dt-label">DMARC</span>
-                    <span className={r.emailrep.dmarc ? 'text-green' : 'text-red'}>{r.emailrep.dmarc ? 'Yes' : 'No'}</span>
-                  </div>
-                  <DtRow label="Domain Reputation" value={r.emailrep.domain_reputation?.toUpperCase()} />
-                  {r.emailrep.disposable && <div className="text-red text-[12px] font-semibold mt-1">⚠ Disposable email detected</div>}
-                  {r.emailrep.spoofable && <div className="text-yellow text-[12px] font-semibold mt-1">⚠ Domain is spoofable (missing SPF/DMARC)</div>}
-                  {r.emailrep.free_provider && <div className="text-text-3 text-[12px] mt-1">Free email provider</div>}
-                  {(r.emailrep.mx_records?.length ?? 0) > 0 && (
-                    <div className="dt-row"><span className="dt-label">MX Records</span>
-                      <div>{r.emailrep.mx_records?.map((mx: string) => <span key={mx} className="tag">{mx}</span>)}</div>
-                    </div>
-                  )}
-                </div>
-              </Card>
-            )}
-            {r.emailrep?.error && (
-              <Card title="Email Reputation" onRefresh={() => refreshModule('emailrep')} refreshing={isRefreshing('emailrep')}>
-                <div className="text-red text-sm">{r.emailrep.error}</div>
-              </Card>
-            )}
-            {r.smtp && !r.smtp.error && (
-              <Card title="SMTP Verification" onRefresh={() => refreshModule('smtp')} refreshing={isRefreshing('smtp')}>
-                <div className="space-y-1.5">
-                  <div className="dt-row"><span className="dt-label">Exists</span>
-                    <span className={r.smtp.exists === true ? 'text-green' : r.smtp.exists === false ? 'text-red' : 'text-text-3'}>
-                      {r.smtp.exists === true ? 'Yes' : r.smtp.exists === false ? 'No' : 'Unknown'}
-                    </span>
-                  </div>
-                  <div className="dt-row"><span className="dt-label">SMTP Connect</span>
-                    <span className={r.smtp.smtp_connect ? 'text-green' : 'text-red'}>{r.smtp.smtp_connect ? 'Yes' : 'No'}</span>
-                  </div>
-                  {r.smtp.catch_all && <div className="text-yellow text-[12px] font-semibold mt-1">⚠ Catch-all server (accepts any address)</div>}
-                  {(r.smtp.details?.length ?? 0) > 0 && (
-                    <div className="mt-2">
-                      <div className="text-[10px] text-text-3 uppercase tracking-wider mb-1">Details</div>
-                      {r.smtp.details?.map((d: string, i: number) => (
-                        <div key={i} className="text-[11px] text-text-2 py-0.5">• {d}</div>
-                      ))}
-                    </div>
-                  )}
-                </div>
-              </Card>
-            )}
-            <KeyModuleCard title="Breach Check" mod={r.breaches} onRefresh={() => refreshModule('leaks', ['breaches'])} refreshing={isRefreshing('leaks')}>
-              <div className="space-y-1.5">
-                {(r.breaches?.breaches?.length ?? 0) === 0 && r.breaches?.found === false && (
-                  <div className="text-green text-sm py-1">✓ No breaches found</div>
-                )}
-                {r.breaches?.found !== undefined && (
-                  <div className="dt-row"><span className="dt-label">Breaches Found</span>
-                    <span className={r.breaches?.found ? 'text-red font-bold' : 'text-green'}>{r.breaches?.found ? 'Yes' : 'No'}</span>
-                  </div>
-                )}
-                {(r.breaches?.breaches?.length ?? 0) > 0 && (
-                  <div className="mt-2">
-                    <div className="text-[10px] text-text-3 uppercase tracking-wider mb-2">Breached Services</div>
-                    <div className="flex flex-wrap gap-1">
-                      {r.breaches?.breaches?.map((b: any, i: number) => (
-                        <span key={i} className="tag tag-red">{typeof b === 'string' ? b : b.name || b.title || JSON.stringify(b)}</span>
-                      ))}
-                    </div>
-                  </div>
-                )}
-                {r.breaches?.total !== undefined && <DtRow label="Total Breaches" value={r.breaches.total} />}
-              </div>
-            </KeyModuleCard>
-          </div>
-        )}
-
-        {tab === 'gravatar' && (
-          <KeyModuleCard
-            title="Gravatar"
-            mod={r.gravatar}
-            onRefresh={() => refreshModule('gravatar')}
-            refreshing={isRefreshing('gravatar')}
-          >
-            <div className="space-y-3">
-              <div className="space-y-1.5">
-                <DtRow label="Display Name" value={r.gravatar?.display_name} />
-                  {r.gravatar?.avatar_url && (
-                    <div className="dt-row">
-                      <span className="dt-label">Avatar URL</span>
-                      <a
-                        href={r.gravatar.avatar_url}
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-blue hover:underline"
-                      >
-                        {r.gravatar.avatar_url}
-                      </a>
-                    </div>
-                  )}
-              </div>
-
-              {(r.gravatar?.accounts?.length ?? 0) > 0 && (
-                <div className="space-y-1.5">
-                  {r.gravatar?.accounts?.map(account => (
-                    <div
-                      key={account.url ?? account.name ?? account.display}
-                      className="dt-row"
-                    >
-                      <span className="dt-label">
-                        {account.name ?? "Account"}
-                      </span>
-
-                      {account.url ? (
-                        <a
-                          href={account.url}
-                          target="_blank"
-                          rel="noreferrer"
-                          className="text-blue hover:underline break-all"
-                        >
-                          {account.display || account.url}
-                        </a>
-                      ) : (
-                        <span>{account.display || "-"}</span>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              )}
-            </div>
-          </KeyModuleCard>
-        )}
-
-        {tab === 'hudsonrock' && (
-          <KeyModuleCard
-            title="Infostealer Exposure"
-            mod={r.hudsonrock}
-            onRefresh={() => refreshModule('hudsonrock')}
-            refreshing={isRefreshing('hudsonrock')}
-          >
-            <div className="space-y-3">
-              <div className="text-[11px] text-text-3 leading-relaxed pb-2 border-b border-border-1">
-                Credentials found on machines infected by infostealer malware. This is separate
-                from breach data: a breach comes from a compromised service, these records come
-                from infected endpoints. Queries are sent to Hudson Rock.
-              </div>
-
-              {r.hudsonrock?.target_type === 'domain' ? (
-                <>
-                  <div className="space-y-1.5">
-                    <DtRow label="Total compromised" value={r.hudsonrock?.total_compromised} />
-                    <DtRow label="Employees" value={r.hudsonrock?.employees} />
-                    <DtRow label="Users" value={r.hudsonrock?.users} />
-                    <DtRow label="Third parties" value={r.hudsonrock?.third_parties} />
-                  </div>
-
-                  {(r.hudsonrock?.employee_urls?.length ?? 0) > 0 && (
-                    <div>
-                      <div className="text-[11px] font-semibold text-text-3 uppercase tracking-wider mb-1.5">
-                        Most affected employee URLs
-                      </div>
-                      <div className="space-y-1.5">
-                        {r.hudsonrock?.employee_urls?.map(entry => (
-                          <div key={entry.url} className="dt-row">
-                            <span className="dt-label break-all">{entry.url}</span>
-                            <span>{entry.occurrence}</span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  {Object.keys(r.hudsonrock?.stealer_families ?? {}).length > 0 && (
-                    <div>
-                      <div className="text-[11px] font-semibold text-text-3 uppercase tracking-wider mb-1.5">
-                        Stealer families
-                      </div>
-                      <div className="space-y-1.5">
-                        {Object.entries(r.hudsonrock?.stealer_families ?? {}).map(([name, count]) => (
-                          <div key={name} className="dt-row">
-                            <span className="dt-label">{name}</span>
-                            <span>{count}</span>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-
-                  {r.hudsonrock?.employee_password_stats && (
-                    <div>
-                      <div className="text-[11px] font-semibold text-text-3 uppercase tracking-wider mb-1.5">
-                        Employee password strength
-                      </div>
-                      <div className="space-y-1.5">
-                        <DtRow label="Passwords analysed" value={r.hudsonrock.employee_password_stats.total} />
-                        <DtRow label="Too weak %" value={r.hudsonrock.employee_password_stats.too_weak} />
-                        <DtRow label="Weak %" value={r.hudsonrock.employee_password_stats.weak} />
-                        <DtRow label="Strong %" value={r.hudsonrock.employee_password_stats.strong} />
-                      </div>
-                    </div>
-                  )}
-                </>
-              ) : (
-                <div className="space-y-1.5">
-                  <DtRow label="Records found" value={r.hudsonrock?.stealers_found} />
-                  <DtRow label="Corporate services" value={r.hudsonrock?.corporate_services} />
-                  <DtRow label="User services" value={r.hudsonrock?.user_services} />
-                </div>
-              )}
-            </div>
-          </KeyModuleCard>
-        )}
-
-        {tab === 'lunar' && (
-          <KeyModuleCard
-            title="Domain Exposure"
-            mod={r.lunar}
-            onRefresh={() => refreshModule('lunar')}
-            refreshing={isRefreshing('lunar')}
-          >
-            <div className="space-y-3">
-              <div className="text-[11px] text-text-3 leading-relaxed pb-2 border-b border-border-1">
-                {"Aggregate counts of how often this domain appears in infostealer logs and breach data over a rolling year, split between staff and customers. Queries are sent to Lunar."}
-              </div>
-
-              <div className="space-y-1.5">
-                <DtRow label="Period" value={r.lunar?.period?.from ? `${r.lunar.period.from} to ${r.lunar.period.to}` : null} />
-                <DtRow label="Total events" value={r.lunar?.total_events} />
-                <DtRow label="Infostealer events" value={r.lunar?.infostealer_events} />
-                <DtRow label="Data breach events" value={r.lunar?.data_breach_events} />
-                <DtRow label="Employee events" value={r.lunar?.employee_events} />
-                <DtRow label="Client events" value={r.lunar?.client_events} />
-                <DtRow label="First seen" value={r.lunar?.first_seen} />
-                <DtRow label="Last seen" value={r.lunar?.last_seen} />
-              </div>
-
-              {(r.lunar?.malware_families?.length ?? 0) > 0 && (
-                <div>
-                  <div className="text-[11px] font-semibold text-text-3 uppercase tracking-wider mb-1.5">
-                    Malware families
-                  </div>
-                  <div className="space-y-1.5">
-                    {r.lunar?.malware_families?.map(entry => (
-                      <div key={entry.family} className="dt-row">
-                        <span className="dt-label">{entry.family}</span>
-                        <span>{entry.events}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {(r.lunar?.services?.length ?? 0) > 0 && (
-                <div>
-                  <div className="text-[11px] font-semibold text-text-3 uppercase tracking-wider mb-1.5">
-                    Affected services
-                  </div>
-                  <div className="space-y-1.5">
-                    {r.lunar?.services?.map(entry => (
-                      <div key={entry.service} className="dt-row">
-                        <span className="dt-label">{entry.service}</span>
-                        <span>{entry.events}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-
-              {(r.lunar?.countries?.length ?? 0) > 0 && (
-                <div>
-                  <div className="text-[11px] font-semibold text-text-3 uppercase tracking-wider mb-1.5">
-                    Countries
-                  </div>
-                  <div className="space-y-1.5">
-                    {r.lunar?.countries?.map(entry => (
-                      <div key={entry.country} className="dt-row">
-                        <span className="dt-label">{entry.country}</span>
-                        <span>{entry.events}</span>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              )}
-            </div>
-          </KeyModuleCard>
-        )}
-
-        {tab === 'dorks' && r.dorks && (
-          <Card title="Google Dorks">
-            {r.dorks.length === 0 ? (
-              <div className="text-text-3 text-sm py-2">No dorks generated</div>
-            ) : (
-              r.dorks.map((d, i) => (
-                <div key={i} className="flex items-center gap-2 py-1.5 border-b border-border-1 last:border-0">
-                  <code className="font-mono text-[11px] text-text-1 flex-1 truncate">{d}</code>
-                  <a href={`https://www.google.com/search?q=${encodeURIComponent(d)}`} target="_blank" rel="noreferrer"
-                    className="text-blue hover:text-white transition-colors flex-shrink-0"
-                    aria-label="Search on Google">
-                    <ExternalLink size={11} />
-                  </a>
-                </div>
-              ))
-            )}
-          </Card>
-        )}
-
-        {tab === 'phone' && r.phone && (
-          <Card title="Phone Intelligence" onRefresh={() => refreshModule('hlr', ['hlr', 'phone_owner', 'phone'])} refreshing={isRefreshing('hlr')}>
-            <div className="space-y-1.5">
-              <div className="dt-row"><span className="dt-label">Valid</span>
-                <span className={r.phone.valid ? 'text-green' : 'text-red'}>{r.phone.valid ? 'Yes' : 'No'}</span>
-              </div>
-              <DtRow label="Country" value={r.phone.country_name} />
-              <DtRow label="Country Code" value={r.phone.country_code} />
-              <DtRow label="Region" value={r.phone.region} />
-              <DtRow label="Carrier" value={r.phone.carrier} />
-              <DtRow label="Line Type" value={r.phone.line_type} />
-              {r.phone.timezones?.length && (
-                <div className="dt-row"><span className="dt-label">Timezones</span>
-                  <div>{r.phone.timezones.map(tz => <span key={tz} className="tag">{tz}</span>)}</div>
-                </div>
-              )}
-              {r.phone.reverse && (
-                <>
-                  <DtRow label="Owner Name" value={r.phone.reverse.name} />
-                  <DtRow label="Address" value={r.phone.reverse.address} />
-                </>
-              )}
-            </div>
-          </Card>
-        )}
-
-        {tab === 'telegram' && r.telegram && (
-          <Card title="Telegram Profile" onRefresh={() => refreshModule('telegram')} refreshing={isRefreshing('telegram')}>
-            {r.telegram.error ? (
-              <div className="text-red text-sm">{r.telegram.error}</div>
-            ) : (
-              <div className="space-y-1.5">
-                <div className="dt-row"><span className="dt-label">Found</span>
-                  <span className={r.telegram.found ? 'text-green' : 'text-red'}>{r.telegram.found ? 'Yes' : 'No'}</span>
-                </div>
-                <DtRow label="Username" value={r.telegram.username} />
-                <DtRow label="Name" value={r.telegram.name} />
-                <DtRow label="Bio" value={r.telegram.bio} />
-                <DtRow label="Type" value={r.telegram.type} />
-                {r.telegram.followers && <DtRow label="Followers" value={r.telegram.followers} />}
-              </div>
-            )}
-          </Card>
-        )}
-
-        {tab === 'map' && (
-          <Card title="IP Geolocation Map">
-            <MapView scanId={scan.id} onCopy={copyValue} />
-          </Card>
-        )}
-
-        {tab === 'graph' && (
-          <Card title="Entity Graph">
-            <div className="flex items-center gap-2 mb-3">
-              <button type="button" onClick={() => exportGraph('graphml')} className="btn-ghost text-[11px] h-8 px-3">
-                <Download size={11} /> GraphML
-              </button>
-              <button type="button" onClick={() => exportGraph('gexf')} className="btn-ghost text-[11px] h-8 px-3">
-                <Download size={11} /> GEXF
-              </button>
-              <span className="text-[10px] text-text-3">Gephi / Maltego</span>
-            </div>
-            <GraphView scanId={scan.id} />
-          </Card>
-        )}
-
-        {tab === 'json' && (
-          <Card title="Raw JSON Results">
-            <div className="flex items-center justify-between mb-3">
-              <button onClick={() => setShowJson(v => !v)} className="flex items-center gap-1.5 text-[11px] text-text-3 hover:text-text-2">
-                {showJson ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
-                {showJson ? 'Hide' : 'Show'} raw data
-              </button>
-              <button
-                type="button"
-                onClick={() => copyValue(JSON.stringify(r, null, 2))}
-                className="flex items-center gap-1 text-[11px] text-text-3 hover:text-text-1 transition-colors p-1 rounded-sm hover:bg-surface-2"
-                title="Copy raw JSON"
-                aria-label="Copy raw JSON"
-              >
-                <Copy size={12} /> Copy
-              </button>
-            </div>
-            {showJson && (
-              <pre className="font-mono text-[10px] text-text-2 overflow-auto max-h-[60vh] bg-surface-1 rounded p-3">
-                {JSON.stringify(r, null, 2)}
-              </pre>
-            )}
-          </Card>
-        )}
-
-        {tab === 'ai' && (
-          <div>
-            <Card title="AI OSINT Analysis · Nvidia Nemotron">
-              <div className="flex gap-2.5 rounded-card border border-yellow/40 bg-yellow/10 p-3 mb-3">
-                <AlertTriangle size={15} className="text-yellow shrink-0 mt-px" />
-                <div className="text-[12px] text-text-1 leading-relaxed">
-                  <div className="font-semibold mb-1">AI analysis does not work on this public demo</div>
-                  <div className="text-text-2">
-                    {"The demo runs on shared hosting whose region every hosted LLM provider refuses at their edge, so the request never reaches a model. Nothing here is broken and no key is missing — the rest of the scan is unaffected. Self-host PRISM and point "}
-                    <code className="font-mono text-[11px]">LLM_BASE_URL</code>
-                    {" and "}
-                    <code className="font-mono text-[11px]">LLM_API_KEY</code>
-                    {" at your own provider, or run a local model, and this panel works normally."}
-                  </div>
-                </div>
-              </div>
-              <div className="text-[11px] text-text-3 leading-relaxed mb-3 pb-3 border-b border-border-1">
-                {"AI-generated and may be inaccurate or incomplete - treat it as a lead, not a verified finding. Generating a summary sends this scan's data to the configured LLM provider. Disable the AI module if you don't want that."}
-              </div>
-              {!aiSummary && !aiLoading && (
-                <button onClick={runAi} className="btn-primary w-full">
-                  <Brain size={13} /> Generate AI Summary
-                </button>
-              )}
-              {aiLoading && (
-                <div className="flex items-center gap-2 text-text-2 text-sm">
-                  <span className="inline-block w-2 h-2 rounded-full bg-blue animate-pulse" />
-                  Generating analysis...
-                </div>
-              )}
-              {aiError && (
-                <div className="text-sm">
-                  <div className="text-red">{aiError}</div>
-                  <div className="text-[11px] text-text-3 leading-relaxed mt-2">
-                    {"This is the hosting-region block described above, not a fault in the scan. Every provider PRISM tried is named in the error."}
-                  </div>
-                </div>
-              )}
-              {aiSummary && (
-                <div>
-                  {aiModel && <div className="text-[10px] text-text-3 mb-3 font-mono">Model: {aiModel}</div>}
-                  <div className="mb-2 flex items-center justify-end">
-                    <CopyIconButton onClick={() => copyValue(aiSummary)} label="Copy summary" />
-                  </div>
-                  <div className="text-[13px] text-text-1 leading-relaxed whitespace-pre-wrap">{aiSummary}</div>
-                  <button onClick={runAi} className="btn-ghost h-8 px-3 text-[11px] mt-4">Regenerate</button>
-                </div>
-              )}
-            </Card>
-
-            <Card title="Ask the AI">
-              <div className="flex gap-2.5 rounded-card border border-yellow/40 bg-yellow/10 p-3 mb-3">
-                <AlertTriangle size={15} className="text-yellow shrink-0 mt-px" />
-                <div className="text-[12px] text-text-2 leading-relaxed">
-                  {"Same as above — the chat cannot reach a model on this demo. It works on a self-hosted instance with your own provider configured."}
-                </div>
-              </div>
-              {chatHistory.length > 0 && (
-                <div className="space-y-3 mb-4 max-h-72 overflow-y-auto pr-1">
-                  {chatHistory.map((m, i) => (
-                    <div key={i} className={`flex gap-2 ${m.role === 'user' ? 'justify-end' : 'justify-start'}`}>
-                      <div className={`max-w-[80%] rounded-lg px-3 py-2 text-[12px] leading-relaxed whitespace-pre-wrap ${
-                        m.role === 'user'
-                          ? 'bg-blue/20 text-text-1 border border-blue/30'
-                          : 'bg-surface-3 text-text-1 border border-border-1'
-                      }`}>
-                        {m.text}
-                      </div>
-                    </div>
-                  ))}
-                  {chatLoading && (
-                    <div className="flex gap-2 justify-start">
-                      <div className="bg-surface-3 border border-border-1 rounded-lg px-3 py-2">
-                        <span className="inline-flex gap-1">
-                          <span className="w-1.5 h-1.5 rounded-full bg-text-3 animate-pulse" />
-                          <span className="w-1.5 h-1.5 rounded-full bg-text-3 animate-pulse delay-75" />
-                          <span className="w-1.5 h-1.5 rounded-full bg-text-3 animate-pulse delay-150" />
-                        </span>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-              <div className="flex gap-2">
-                <input
-                  value={chatInput}
-                  onChange={e => setChatInput(e.target.value)}
-                  onKeyDown={e => e.key === 'Enter' && !e.shiftKey && sendChat()}
-                  placeholder="Ask anything about this scan..."
-                  className="input-field flex-1 text-[12px]"
-                  disabled={chatLoading}
-                />
-                <button
-                  onClick={sendChat}
-                  disabled={!chatInput.trim() || chatLoading}
-                  className="btn-primary px-3 h-9 shrink-0"
-                  aria-label="Send message"
-                >
-                  <SendHorizontal size={13} />
-                </button>
-              </div>
-            </Card>
-          </div>
-        )}
-      </div>
-      {showBackToTop && (
-        <div className="fixed bottom-8 right-8 z-50 group">
-          <button
-            type="button"
-            onClick={() => {
-              const el = contentRef.current;
-              if (el) el.scrollTo({ top: 0, behavior: 'smooth' });
-              else window.scrollTo({ top: 0, behavior: 'smooth' });
-            }}
-            aria-label="Back to top"
-            title="Back to top"
-            className="flex items-center justify-center w-12 h-12 rounded-full bg-blue hover:bg-blue/90 text-white shadow-lg hover:shadow-xl focus:outline-none focus:ring-2 focus:ring-blue/50 focus:ring-offset-2 focus:ring-offset-surface-1 transition-all duration-200 hover:scale-110 active:scale-95"
-          >
-            <ArrowUp size={20} strokeWidth={2.5} />
-            <span className="sr-only">Back to top</span>
-          </button>
-          <div className="absolute -top-12 left-1/2 -translate-x-1/2 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none whitespace-nowrap">
-            <div className="px-3 py-1.5 rounded-md bg-surface-1 border border-border-1 text-[11px] font-semibold text-text-1 shadow-lg">Back to top</div>
-          </div>
-        </div>
-      )}
-
-      {copyToast && (
-        <div className={`fixed ${showBackToTop ? 'bottom-20' : 'bottom-4'} right-4 z-[70] px-3 py-1.5 rounded border border-border-1 bg-surface-2 text-[11px] font-semibold text-text-1 shadow-xl`}>
-          {copyToast}
-        </div>
-      )}
+        );
+      })}
     </div>
   );
 }

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,1 +1,21 @@
-
+from modules.darkweb_search import DarkWebSearch
+from modules.url_scanner import URLScanner
+from modules.qr_decoder import QRDecoder
+from modules.graph_export import to_graphml, to_gexf
+from modules.censys_lookup import CensysLookup
+from modules.gravatar import GravatarRecon
+from modules.module_status import (
+    annotate,
+    classify,
+    reason_for,
+    status_notice,
+    print_status_notice,
+    OK,
+    SKIPPED,
+    RATE_LIMITED,
+    ERROR,
+)
+from modules.onion_checker import OnionChecker
+from modules.webhook_formatters import format_slack, format_discord
+from modules.cert_transparency import CertTransparency
+from modules.rdap import RDAPLookup

--- a/modules/rdap.py
+++ b/modules/rdap.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import requests
+
+from modules.module_status import annotate, OK, SKIPPED, ERROR
+
+# IANA bootstrap file for RDAP server discovery
+IANA_BOOTSTRAP_URL = "https://data.iana.org/rdap/dns.json"
+
+
+class RDAPLookup:
+    """RDAP domain registration lookup.
+
+    Queries the RDAP (Registration Data Access Protocol) service for domain
+    registration information. RDAP is the modern replacement for WHOIS,
+    providing structured JSON responses over HTTPS.
+
+    This module uses the IANA bootstrap file to discover the correct RDAP
+    server for each TLD, falling back to rdap.org as a resolver if needed.
+    """
+
+    def __init__(self, timeout: int = 15, use_bootstrap: bool = True):
+        self.timeout = timeout
+        self.use_bootstrap = use_bootstrap
+        self._bootstrap_cache: Optional[Dict[str, str]] = None
+
+    def _load_bootstrap(self) -> Dict[str, str]:
+        """Load the IANA RDAP bootstrap file and cache it."""
+        if self._bootstrap_cache is not None:
+            return self._bootstrap_cache
+
+        try:
+            r = requests.get(IANA_BOOTSTRAP_URL, timeout=self.timeout)
+            if r.status_code != 200:
+                return {}
+
+            data = r.json()
+            services = data.get("services", [])
+            tld_map: Dict[str, str] = {}
+
+            for service in services:
+                # Each service entry: [["tld1", "tld2", ...], ["rdap_url1", "rdap_url2", ...]]
+                if not isinstance(service, list) or len(service) < 2:
+                    continue
+
+                tlds = service[0] if isinstance(service[0], list) else []
+                urls = service[1] if isinstance(service[1], list) else []
+
+                # Skip if no TLDs or URLs
+                if not tlds or not urls:
+                    continue
+
+                # Use the first RDAP URL for each TLD
+                rdap_url = urls[0]
+                for tld in tlds:
+                    if isinstance(tld, str):
+                        tld_map[tld.lower()] = rdap_url
+
+            self._bootstrap_cache = tld_map
+            return tld_map
+
+        except Exception:
+            return {}
+
+    def _get_rdap_url(self, domain: str) -> str:
+        """Get the appropriate RDAP server URL for a domain."""
+        domain_lower = domain.lower().strip()
+        domain = domain_lower.rstrip(".")
+
+        # Extract TLD
+        parts = domain.split(".")
+        if len(parts) < 2:
+            tld = parts[-1] if parts else ""
+        else:
+            tld = parts[-1]
+
+        tld_lower = tld.lower()
+
+        # Try bootstrap file first
+        if self.use_bootstrap:
+            tld_map = self._load_bootstrap()
+            if tld_lower in tld_map:
+                base_url = tld_map[tld_lower]
+                # Ensure URL ends with a slash
+                if not base_url.endswith("/"):
+                    base_url += "/"
+                return f"{base_url}domain/{domain}"
+
+        # Fallback: use rdap.org as a resolver
+        return f"https://rdap.org/domain/{domain}"
+
+    def _format_date(self, date_str: Optional[str]) -> Optional[str]:
+        """Format a date string to ISO 8601 if possible."""
+        if not date_str:
+            return None
+
+        # Try to parse ISO 8601
+        try:
+            # If it's already ISO-like, just return it
+            if re.match(r"^\d{4}-\d{2}-\d{2}", date_str):
+                return date_str
+            # Try common RDAP date formats
+            # Some registries use different formats
+            return date_str
+        except Exception:
+            return date_str
+
+    def _parse_contact(self, entity: Dict[str, Any]) -> Dict[str, Optional[str]]:
+        """Parse a contact entity from RDAP response."""
+        contact = {
+            "name": None,
+            "email": None,
+            "phone": None,
+            "organization": None,
+            "country": None,
+        }
+
+        # Try to get the handle or name
+        contact["name"] = entity.get("handle") or entity.get("fn")
+
+        # Look for vCard data
+        vcard = entity.get("vcardArray", [])
+        if len(vcard) > 1 and isinstance(vcard[1], list):
+            for prop in vcard[1]:
+                if not isinstance(prop, list) or len(prop) < 3:
+                    continue
+                prop_name = prop[0]
+                prop_value = prop[2] if len(prop) > 2 else None
+
+                if prop_name == "fn":
+                    contact["name"] = prop_value
+                elif prop_name == "email":
+                    contact["email"] = prop_value
+                elif prop_name == "tel":
+                    contact["phone"] = prop_value
+                elif prop_name == "org":
+                    contact["organization"] = prop_value
+                elif prop_name == "adr" and isinstance(prop_value, list):
+                    # vCard address: ["", "", "street", "locality", "region", "postal", "country"]
+                    if len(prop_value) > 6:
+                        contact["country"] = prop_value[6]
+
+        # Also check top-level fields
+        if not contact["organization"]:
+            contact["organization"] = entity.get("org")
+
+        return contact
+
+    def lookup(self, domain: str) -> Dict[str, Any]:
+        """Perform RDAP lookup for a domain."""
+        domain = (domain or "").strip().lower()
+        domain = domain.rstrip(".")
+
+        result: Dict[str, Any] = {
+            "domain": domain,
+            "rdap_url": None,
+            "status": None,
+            "created": None,
+            "expires": None,
+            "updated": None,
+            "registrar": None,
+            "registrant": None,
+            "administrative": None,
+            "technical": None,
+            "nameservers": [],
+            "raw": None,
+            "error": None,
+        }
+
+        if not domain:
+            return annotate(result, ERROR, "No domain provided")
+
+        # Validate domain format
+        if not re.match(r"^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$", domain):
+            return annotate(result, ERROR, f"Invalid domain format: {domain}")
+
+        rdap_url = self._get_rdap_url(domain)
+        result["rdap_url"] = rdap_url
+
+        try:
+            r = requests.get(
+                rdap_url,
+                timeout=self.timeout,
+                headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
+            )
+
+            if r.status_code == 404:
+                # Domain not registered
+                result["status"] = "unregistered"
+                return annotate(result, OK, "Domain is not registered")
+
+            if r.status_code == 403:
+                return annotate(
+                    result,
+                    SKIPPED,
+                    "RDAP server refused the request (access denied)",
+                )
+
+            if r.status_code == 429:
+                return annotate(
+                    result,
+                    SKIPPED,
+                    "RDAP server rate limited the request",
+                )
+
+            if r.status_code != 200:
+                # Check if it's a redirect to a different RDAP server
+                if r.status_code in (301, 302, 303, 307, 308):
+                    location = r.headers.get("location")
+                    if location:
+                        result["rdap_url"] = location
+                        # Follow the redirect with a single attempt
+                        try:
+                            r2 = requests.get(
+                                location,
+                                timeout=self.timeout,
+                                headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
+                            )
+                            if r2.status_code == 200:
+                                r = r2
+                            else:
+                                return annotate(
+                                    result,
+                                    SKIPPED,
+                                    f"RDAP unavailable for this TLD (HTTP {r.status_code})",
+                                )
+                        except Exception:
+                            return annotate(
+                                result,
+                                SKIPPED,
+                                "RDAP unavailable for this TLD",
+                            )
+                    else:
+                        return annotate(
+                            result,
+                            SKIPPED,
+                            f"RDAP unavailable for this TLD (HTTP {r.status_code})",
+                        )
+                else:
+                    return annotate(
+                        result,
+                        SKIPPED,
+                        f"RDAP unavailable (HTTP {r.status_code})",
+                    )
+
+            data = r.json()
+
+            # Parse the response
+            result["status"] = "registered"
+
+            # Dates
+            result["created"] = self._format_date(data.get("events", {}).get("registration") or data.get("registrationDate"))
+            result["expires"] = self._format_date(data.get("events", {}).get("expiration") or data.get("expirationDate"))
+
+            # Look for events
+            events = data.get("events", [])
+            if isinstance(events, list):
+                for event in events:
+                    if not isinstance(event, dict):
+                        continue
+                    action = event.get("eventAction") or event.get("action")
+                    date = event.get("eventDate") or event.get("date")
+                    if action == "registration":
+                        result["created"] = self._format_date(date)
+                    elif action == "expiration":
+                        result["expires"] = self._format_date(date)
+                    elif action == "last changed" or action == "lastChanged":
+                        result["updated"] = self._format_date(date)
+
+            # Registrar
+            entities = data.get("entities", [])
+            for entity in entities:
+                if not isinstance(entity, dict):
+                    continue
+                roles = entity.get("roles") or entity.get("role") or []
+                if not isinstance(roles, list):
+                    roles = [roles] if roles else []
+
+                if "registrar" in roles or "registrar" in entity.get("type", "").lower():
+                    result["registrar"] = entity.get("handle") or entity.get("fn")
+
+                if "registrant" in roles:
+                    result["registrant"] = self._parse_contact(entity)
+
+                if "administrative" in roles or "admin" in roles:
+                    result["administrative"] = self._parse_contact(entity)
+
+                if "technical" in roles:
+                    result["technical"] = self._parse_contact(entity)
+
+            # Nameservers
+            nameservers = data.get("nameservers", [])
+            if isinstance(nameservers, list):
+                for ns in nameservers:
+                    if isinstance(ns, dict):
+                        ns_name = ns.get("ldhName") or ns.get("fqdn") or ns.get("name")
+                        if ns_name:
+                            result["nameservers"].append(ns_name)
+
+            result["raw"] = data
+            return annotate(result, OK)
+
+        except requests.Timeout:
+            return annotate(
+                result,
+                SKIPPED,
+                "RDAP request timed out",
+            )
+        except requests.ConnectionError:
+            return annotate(
+                result,
+                SKIPPED,
+                "RDAP connection error",
+            )
+        except Exception as e:
+            return annotate(
+                result,
+                ERROR,
+                str(e)[:200],
+            )
+
+
+def run_rdap_lookup(domain: str) -> Dict[str, Any]:
+    """Convenience function for CLI usage."""
+    rdap = RDAPLookup()
+    return rdap.lookup(domain)

--- a/tests/test_rdap.py
+++ b/tests/test_rdap.py
@@ -1,0 +1,233 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from modules.rdap import RDAPLookup
+from modules.module_status import classify, OK, SKIPPED, ERROR
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, data=None, headers=None):
+        self.status_code = status_code
+        self._data = data or {}
+        self.headers = headers or {}
+
+    def json(self):
+        return self._data
+
+
+# Sample RDAP response for a registered domain
+REGISTERED_RESPONSE = {
+    "handle": "123456789_DOMAIN_COM-VRSN",
+    "ldhName": "example.com",
+    "registrationDate": "1995-08-14T04:00:00Z",
+    "expirationDate": "2025-08-13T04:00:00Z",
+    "events": [
+        {"eventAction": "registration", "eventDate": "1995-08-14T04:00:00Z"},
+        {"eventAction": "expiration", "eventDate": "2025-08-13T04:00:00Z"},
+        {"eventAction": "last changed", "eventDate": "2023-05-01T12:00:00Z"},
+    ],
+    "entities": [
+        {
+            "handle": "REG-123",
+            "fn": "Example Registrar",
+            "roles": ["registrar"],
+        },
+        {
+            "handle": "R-001",
+            "fn": "Domain Owner",
+            "roles": ["registrant"],
+            "vcardArray": [
+                "vcard",
+                [
+                    ["fn", {}, "Domain Owner"],
+                    ["org", {}, "Example Corp"],
+                    ["email", {}, "admin@example.com"],
+                    ["tel", {}, "+1-555-123-4567"],
+                    ["adr", {}, ["", "", "123 Main St", "Anytown", "CA", "90210", "US"]],
+                ],
+            ],
+        },
+    ],
+    "nameservers": [
+        {"ldhName": "ns1.example.com"},
+        {"ldhName": "ns2.example.com"},
+    ],
+}
+
+
+def test_rdap_lookup_registered_domain(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse(200, REGISTERED_RESPONSE)
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+
+        assert classify(result) == OK
+        assert result["domain"] == "example.com"
+        assert result["status"] == "registered"
+        assert result["created"] == "1995-08-14T04:00:00Z"
+        assert result["expires"] == "2025-08-13T04:00:00Z"
+        assert result["updated"] == "2023-05-01T12:00:00Z"
+        assert result["registrar"] == "Example Registrar"
+        assert "ns1.example.com" in result["nameservers"]
+        assert "ns2.example.com" in result["nameservers"]
+        assert result["registrant"] is not None
+        assert result["registrant"].get("name") == "Domain Owner"
+        assert result["registrant"].get("email") == "admin@example.com"
+        assert result["error"] is None
+
+
+def test_rdap_lookup_unregistered_domain(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse(404, {})
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("notarealdomain123456789.com")
+
+        assert classify(result) == OK
+        assert result["status"] == "unregistered"
+        assert result["error"] is None
+
+
+def test_rdap_lookup_empty_domain():
+    rdap = RDAPLookup()
+    result = rdap.lookup("")
+    assert classify(result) == ERROR
+    assert "No domain provided" in result["error"]
+
+
+def test_rdap_lookup_invalid_domain():
+    rdap = RDAPLookup()
+    result = rdap.lookup("invalid@@domain")
+    assert classify(result) == ERROR
+    assert "Invalid domain format" in result["error"]
+
+
+def test_rdap_lookup_tld_not_served(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse(501, {})
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.xx")
+
+        assert classify(result) == SKIPPED
+        assert "RDAP unavailable" in result["status_reason"]
+        assert result["error"] is None
+
+
+def test_rdap_lookup_rate_limited(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse(429, {})
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+
+        assert classify(result) == SKIPPED
+        assert "rate limited" in result["status_reason"]
+        assert result["error"] is None
+
+
+def test_rdap_lookup_timeout(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.side_effect = requests.exceptions.Timeout()
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+
+        assert classify(result) == SKIPPED
+        assert "timed out" in result["status_reason"]
+        assert result["error"] is None
+
+
+def test_rdap_lookup_connection_error(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.side_effect = requests.exceptions.ConnectionError()
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+
+        assert classify(result) == SKIPPED
+        assert "connection" in result["status_reason"]
+        assert result["error"] is None
+
+
+def test_rdap_bootstrap_loading(monkeypatch):
+    bootstrap_data = {
+        "services": [
+            [
+                ["com", "net", "org"],
+                ["https://rdap.verisign.com/com/v1/", "https://rdap.verisign.com/net/v1/"],
+            ],
+            [["de"], ["https://rdap.denic.de/"]],
+        ]
+    }
+
+    with patch("modules.rdap.requests.get") as mock_get:
+        # First call: bootstrap
+        # Second call: RDAP lookup
+        mock_get.side_effect = [
+            FakeResponse(200, bootstrap_data),
+            FakeResponse(200, REGISTERED_RESPONSE),
+        ]
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+
+        # Verify bootstrap was used
+        assert mock_get.call_count == 2
+        first_call = mock_get.call_args_list[0]
+        assert first_call[0][0] == "https://data.iana.org/rdap/dns.json"
+
+        # Verify the RDAP URL is correct
+        second_call = mock_get.call_args_list[1]
+        assert "rdap.verisign.com" in second_call[0][0]
+        assert "example.com" in second_call[0][0]
+
+        assert classify(result) == OK
+
+
+def test_rdap_bootstrap_fallback(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        # Bootstrap returns empty (404)
+        # Then RDAP call to rdap.org
+        mock_get.side_effect = [
+            FakeResponse(404, {}),
+            FakeResponse(200, REGISTERED_RESPONSE),
+        ]
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+
+        # Verify fallback to rdap.org
+        assert mock_get.call_count == 2
+        second_call = mock_get.call_args_list[1]
+        assert "rdap.org" in second_call[0][0]
+
+        assert classify(result) == OK
+
+
+def test_rdap_lookup_redirect_following(monkeypatch):
+    # RDAP response that redirects to another server
+    with patch("modules.rdap.requests.get") as mock_get:
+        redirect_response = FakeResponse(
+            302,
+            {},
+            {"location": "https://rdap.verisign.com/com/v1/domain/example.com"},
+        )
+        mock_get.side_effect = [
+            redirect_response,
+            FakeResponse(200, REGISTERED_RESPONSE),
+        ]
+
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+
+        assert mock_get.call_count == 2
+        second_call = mock_get.call_args_list[1]
+        assert "rdap.verisign.com" in second_call[0][0]
+        assert classify(result) == OK

--- a/web/app.py
+++ b/web/app.py
@@ -1,1547 +1,735 @@
+"""
+PRISM - Open Source Intelligence Platform
+FastAPI backend with WebSocket scan engine.
+"""
+
 import asyncio
 import json
 import os
-import sys
-import time
-import uuid
-import threading
-from datetime import datetime
-from pathlib import Path
-from typing import Any, Dict, List, Optional
 import re
-import requests as _requests
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Set
+from contextlib import asynccontextmanager
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect, UploadFile, File, Depends, Request
-from fastapi.responses import FileResponse, JSONResponse, Response
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
-from pydantic import BaseModel
-from slowapi import _rate_limit_exceeded_handler
-from slowapi.errors import RateLimitExceeded
-from slowapi.middleware import SlowAPIMiddleware
-from starlette.middleware.trustedhost import TrustedHostMiddleware
-from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
+from fastapi.responses import HTMLResponse, JSONResponse, FileResponse
+from fastapi.staticfiles import StaticFiles
+import uvicorn
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-import config
-
-from modules.graph_builder import build_graph
-from modules.module_status import classify, reason_for, OK, ERROR
-from modules.opsec_score import score_from_results
+from modules.cert_transparency import CertTransparency
+from modules.darkweb_search import DarkWebSearch
+from modules.gravatar import GravatarRecon
+from modules.onion_checker import OnionChecker
+from modules.rdap import RDAPLookup
+from modules.shodan_lookup import ShodanLookup
+from modules.virustotal_lookup import VirusTotalLookup
+from modules.abuseipdb_lookup import AbuseIPDBLookup
+from modules.github_recon import GitHubRecon
+from modules.breach_check import BreachCheck
+from modules.whois_lookup import WhoisLookup
+from modules.dns_lookup import DNSLookup
+from modules.geoip import GeoIP
+from modules.wayback import Wayback
 from modules.report_generator import generate_html_report, generate_pdf_report
-from modules.webhook_formatters import format_slack, format_discord
-
-GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
-OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
-_OPENROUTER_URL = "https://openrouter.ai/api/v1/chat/completions"
-_GROQ_URL = "https://api.groq.com/openai/v1/chat/completions"
-_LLM_KEY = os.getenv("LLM_API_KEY") or OPENROUTER_API_KEY or GROQ_API_KEY
-_LLM_URL = os.getenv("LLM_BASE_URL") or (_OPENROUTER_URL if OPENROUTER_API_KEY else _GROQ_URL)
-_LLM_MODEL = os.getenv("LLM_MODEL") or ("nvidia/nemotron-3-nano-30b-a3b:free" if OPENROUTER_API_KEY else "llama-3.1-8b-instant")
-_LLM_PROXY = os.getenv("LLM_PROXY", "").strip()
-_LLM_PROXIES = {"http": _LLM_PROXY, "https": _LLM_PROXY} if _LLM_PROXY else None
-
-
-def llm_providers() -> List[Dict[str, str]]:
-    providers = []
-    custom_key = os.getenv("LLM_API_KEY", "").strip()
-    custom_url = os.getenv("LLM_BASE_URL", "").strip()
-    if custom_key or custom_url:
-        providers.append({
-            "name": "custom",
-            "url": custom_url or _OPENROUTER_URL,
-            "key": custom_key or "local",
-            "model": os.getenv("LLM_MODEL", "").strip() or "nvidia/nemotron-3-nano-30b-a3b:free",
-        })
-    if OPENROUTER_API_KEY and not any(p["key"] == OPENROUTER_API_KEY for p in providers):
-        providers.append({
-            "name": "openrouter",
-            "url": _OPENROUTER_URL,
-            "key": OPENROUTER_API_KEY,
-            "model": os.getenv("LLM_MODEL", "").strip() or "nvidia/nemotron-3-nano-30b-a3b:free",
-        })
-    if GROQ_API_KEY and not any(p["key"] == GROQ_API_KEY for p in providers):
-        providers.append({
-            "name": "groq",
-            "url": _GROQ_URL,
-            "key": GROQ_API_KEY,
-            "model": os.getenv("GROQ_MODEL", "").strip() or "llama-3.1-8b-instant",
-        })
-    return providers
-
+from modules.graph_export import to_graphml, to_gexf
 from web.security import (
-    require_api_key, validate_target, check_upload_size, get_allowed_origins,
-    limiter, validate_scan_id, validate_url_not_private, validate_public_target,
-    get_principal, principal_for_key, ANONYMOUS_PRINCIPAL,
-    env_flag, normalize_base_path, parse_csv_env,
-    check_scan_quota, record_scan, get_usage,
+    validate_api_key,
+    validate_public_target,
+    client_ip,
+    check_rate_limit,
+    check_scan_quota,
+    record_scan,
+    get_usage,
+)
+from web.watchlist import (
+    create_watchlist,
+    list_watchlists,
+    get_watchlist,
+    delete_watchlist,
+    set_paused,
+    get_watchlist_status,
+    due_watchlists,
+    record_run,
+    mark_error,
+    WATCHLIST_SCHEDULER,
 )
 
-_disable_docs = os.getenv("DISABLE_DOCS", "").lower() in ("1", "true", "yes")
-_BASE_PATH = normalize_base_path(os.getenv("PRISM_BASE_PATH", ""))
-_TRUST_PROXY_HEADERS = env_flag("TRUST_PROXY_HEADERS")
-_FORWARDED_ALLOW_IPS = os.getenv("FORWARDED_ALLOW_IPS", "127.0.0.1,::1").strip() or "127.0.0.1,::1"
-_TRUSTED_HOSTS = parse_csv_env("TRUSTED_HOSTS")
-_PROJECT_ROOT = Path(__file__).resolve().parents[1]
-_FRONTEND_DIR = Path(os.getenv("PRISM_FRONTEND_DIR") or (_PROJECT_ROOT / "frontend" / "out")).resolve()
-_RESERVED_FRONTEND_PATHS = {"api", "ws", "healthz", "docs", "redoc", "openapi.json"}
+# Import config
+from config import (
+    ALLOW_ANON_API,
+    API_KEYS,
+    PRISM_UI_API_KEY,
+    PRISM_FRONTEND_DIR,
+    PRISM_BASE_PATH,
+    ALLOWED_ORIGINS,
+    DISABLE_DOCS,
+    MAX_STORED_SCANS,
+)
+
+# LLM imports
+from web.llm import llm_providers, _llm_complete
+
+# Initialize FastAPI
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup
+    if WATCHLIST_SCHEDULER:
+        import asyncio
+        asyncio.create_task(run_watchlist_scheduler())
+    yield
+    # Shutdown
 
 app = FastAPI(
-    title="OSINT Toolkit",
+    title="PRISM OSINT API",
+    description="Self-hosted OSINT platform API",
     version="2.8.0",
-    root_path=_BASE_PATH,
-    docs_url=None if _disable_docs else "/docs",
-    redoc_url=None if _disable_docs else "/redoc",
-    openapi_url=None if _disable_docs else "/openapi.json",
+    lifespan=lifespan,
 )
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+
+# CORS configuration
+origins = []
+if ALLOWED_ORIGINS == "*":
+    origins = ["*"]
+else:
+    origins = [o.strip() for o in ALLOWED_ORIGINS.split(",") if o.strip()]
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=get_allowed_origins(),
-    allow_methods=["GET", "POST", "OPTIONS"],
-    allow_headers=["Content-Type", "X-API-Key", "Authorization"],
-    allow_credentials=False,
+    allow_origins=origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
 )
-app.add_middleware(SlowAPIMiddleware)
 
-@app.middleware("http")
-async def add_security_headers(request, call_next):
-    response = await call_next(request)
-    response.headers["X-Content-Type-Options"] = "nosniff"
-    response.headers["X-Frame-Options"] = "DENY"
-    response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
-    response.headers["Permissions-Policy"] = "geolocation=(), camera=(), microphone=()"
-    return response
-
-if _TRUSTED_HOSTS and _TRUSTED_HOSTS != ["*"]:
-    app.add_middleware(TrustedHostMiddleware, allowed_hosts=_TRUSTED_HOSTS)
-
-if _TRUST_PROXY_HEADERS:
-    app.add_middleware(ProxyHeadersMiddleware, trusted_hosts=_FORWARDED_ALLOW_IPS)
-
-@app.on_event("startup")
-async def _startup_banner() -> None:
-    base_note = f" (public base path: {_BASE_PATH})" if _BASE_PATH else ""
-    print(
-        f"\n  PRISM is running on http://localhost:8080{base_note}\n"
-        "  ⭐ If you find it useful, star the repo: "
-        "https://github.com/NovaCode37/Prism-platform\n",
-        flush=True,
-    )
-    _start_watchlist_scheduler()
-
-_scans: Dict[str, Dict] = {}
-_queues: Dict[str, asyncio.Queue] = {}
-MAX_STORED_SCANS = int(os.getenv("MAX_STORED_SCANS") or "200")
-
-_SCANS_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scan_data")
-os.makedirs(_SCANS_DIR, exist_ok=True)
-
-_CACHE_DIR = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "module_cache")
-os.makedirs(_CACHE_DIR, exist_ok=True)
-_CACHE_TTL = int(os.getenv("CACHE_TTL_HOURS") or "24") * 3600
-
-def _cache_key(module: str, target: str) -> str:
-    import hashlib
-    h = hashlib.md5(f"{module}:{target.lower().strip()}".encode()).hexdigest()
-    return os.path.join(_CACHE_DIR, f"{module}_{h}.json")
-
-def _get_cached(module: str, target: str) -> Optional[Dict]:
-    path = _cache_key(module, target)
-    if not os.path.exists(path):
-        return None
-    try:
-        age = time.time() - os.path.getmtime(path)
-        if age > _CACHE_TTL:
-            os.remove(path)
-            return None
-        with open(path, "r", encoding="utf-8") as f:
-            return json.load(f)
-    except Exception:
-        return None
-
-def _set_cache(module: str, target: str, data: Any) -> None:
-    try:
-        with open(_cache_key(module, target), "w", encoding="utf-8") as f:
-            json.dump(data, f, default=str)
-    except Exception:
-        pass
-
-def _geocode_place(query: str) -> Optional[Dict]:
-    import hashlib
-    cache_path = os.path.join(_CACHE_DIR, "geocode_" + hashlib.md5(query.lower().encode()).hexdigest() + ".json")
-    try:
-        if os.path.exists(cache_path) and time.time() - os.path.getmtime(cache_path) < 30 * 86400:
-            with open(cache_path, "r", encoding="utf-8") as f:
-                return json.load(f)
-    except Exception:
-        pass
-    place = None
-    try:
-        r = _requests.get(
-            "https://nominatim.openstreetmap.org/search",
-            params={"q": query, "format": "json", "limit": 1},
-            headers={"User-Agent": "PRISM-OSINT/2.3 (https://github.com/NovaCode37/Prism-platform)"},
-            timeout=8,
-        )
-        arr = r.json()
-        if arr:
-            bb = arr[0].get("boundingbox")
-            bbox = [float(bb[0]), float(bb[1]), float(bb[2]), float(bb[3])] if bb and len(bb) == 4 else None
-            place = {"lat": float(arr[0]["lat"]), "lng": float(arr[0]["lon"]), "bbox": bbox}
-    except Exception:
-        return None
-    try:
-        with open(cache_path, "w", encoding="utf-8") as f:
-            json.dump(place, f)
-    except Exception:
-        pass
-    return place
-
-def _scan_path(scan_id: str) -> str:
-    return os.path.join(_SCANS_DIR, f"{scan_id}.json")
-
-def _save_scan(scan_id: str, data: Dict) -> None:
-    safe = {k: v for k, v in data.items() if k != "results" or v is not None}
-    try:
-        with open(_scan_path(scan_id), "w", encoding="utf-8") as f:
-            json.dump(safe, f, default=str)
-    except Exception:
-        pass
-
-def _load_scan(scan_id: str) -> Optional[Dict]:
-    if scan_id in _scans:
-        return _scans[scan_id]
-    p = _scan_path(scan_id)
-    if os.path.exists(p):
-        try:
-            with open(p, "r", encoding="utf-8") as f:
-                return json.load(f)
-        except Exception:
-            pass
-    return None
-
-def _list_scans_from_disk(principal: Optional[str] = None) -> List[Dict]:
-    result = []
-    try:
-        for fname in os.listdir(_SCANS_DIR):
-            if not fname.endswith(".json"):
-                continue
-            try:
-                with open(os.path.join(_SCANS_DIR, fname), "r", encoding="utf-8") as f:
-                    s = json.load(f)
-            except Exception:
-                continue
-            if principal is not None:
-                if (s.get("owner") or ANONYMOUS_PRINCIPAL) != principal:
-                    continue
-            result.append(s)
-    except Exception:
-        pass
-    result.sort(key=lambda s: s.get("started_at") or "", reverse=True)
-    return result[:50]
-
-def _scan_visible_to(scan: Dict, principal: str) -> bool:
-    return (scan.get("owner") or ANONYMOUS_PRINCIPAL) == principal
-
-def _evict_old_scans() -> None:
-    if len(_scans) <= MAX_STORED_SCANS:
-        return
-    completed = sorted(
-        ((k, v) for k, v in _scans.items() if v.get("status") in ("completed", "error")),
-        key=lambda x: x[1].get("started_at", ""),
-    )
-    to_remove = len(_scans) - MAX_STORED_SCANS
-    for k, _ in completed[:to_remove]:
-        _scans.pop(k, None)
-        _queues.pop(k, None)
-
-class ScanRequest(BaseModel):
-    target: str
-    scan_type: str = "auto"
-    modules: List[str] = []
-    webhook_url: Optional[str] = None
-    force_refresh: bool = False
-
-class WatchlistRequest(BaseModel):
-    target: str
-    scan_type: str = "auto"
-    modules: List[str] = []
-    interval_hours: float = 24.0
-    webhook_url: Optional[str] = None
-
-class WatchlistPatchRequest(BaseModel):
-    paused: bool
-
-WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "").strip()
-
-def _is_public_ip(addr) -> bool:
-    return not (
-        addr.is_private or addr.is_loopback or addr.is_reserved
-        or addr.is_link_local or addr.is_multicast or addr.is_unspecified
-    )
-
-def _resolve_all_public(hostname: str) -> None:
-    import ipaddress
-    import socket
-    try:
-        infos = socket.getaddrinfo(hostname, None)
-    except socket.gaierror:
-        try:
-            fallback_ip = socket.gethostbyname(hostname)
-        except socket.gaierror:
-            raise ValueError("webhook_url hostname cannot be resolved")
-        try:
-            addr = ipaddress.ip_address(fallback_ip)
-        except ValueError:
-            raise ValueError("webhook_url resolved to an invalid address")
-        if not _is_public_ip(addr):
-            raise ValueError("webhook_url resolves to a private/internal address")
-        return
-    seen = set()
-    for fam, _t, _p, _c, sa in infos:
-        ip_str = sa[0]
-        if ip_str in seen:
-            continue
-        seen.add(ip_str)
-        try:
-            addr = ipaddress.ip_address(ip_str)
-        except ValueError:
-            raise ValueError("webhook_url resolved to an invalid address")
-        if not _is_public_ip(addr):
-            raise ValueError("webhook_url resolves to a private/internal address")
-    if not seen:
-        raise ValueError("webhook_url hostname did not resolve")
-
-def _validate_webhook_url(url: str) -> str:
-    from urllib.parse import urlparse
-    if not url or len(url) > 2048:
-        raise ValueError("webhook_url is empty or too long")
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https") or not parsed.hostname:
-        raise ValueError("webhook_url must be http(s) with a hostname")
-    _resolve_all_public(parsed.hostname)
-    try:
-                                                                            
-                                                              
-        _requests.head(url, timeout=3, allow_redirects=False)
-    except Exception:
-                                                                       
-        pass
-    return url
-
-def _run_watchlist_once(entry: Dict[str, Any]) -> None:
-    from web import watchlist
-    import cli
-    wid = entry["id"]
-    modules = entry.get("modules") or None
-    try:
-        results = asyncio.run(cli.run_scan(entry["target"], entry["scan_type"], modules))
-    except Exception:
-        watchlist.mark_error(wid)
-        return
-    alert = watchlist.record_run(wid, results)
-    if alert and entry.get("webhook_url"):
-        payload = {
-            "event": "watchlist_alert",
-            "watchlist_id": wid,
-            "target": entry["target"],
-            "scan_type": entry["scan_type"],
-            "added": alert["added_count"],
-            "removed": alert["removed_count"],
-            "changes": (alert["added"][:10] + [f"-{c}" for c in alert["removed"][:10]]),
-        }
-        _send_webhook(entry["webhook_url"], payload)
-
-def _watchlist_scheduler_loop() -> None:
-    poll = int(os.getenv("WATCHLIST_POLL_SECONDS") or "60")
-    while True:
-        try:
-            if env_flag("WATCHLIST_SCHEDULER", True):
-                from web import watchlist
-                for entry in watchlist.due_watchlists():
-                    _run_watchlist_once(entry)
-        except Exception:
-            pass
-        time.sleep(poll)
-
-_watchlist_thread_started = False
-
-def _start_watchlist_scheduler() -> None:
-    global _watchlist_thread_started
-    if _watchlist_thread_started or not env_flag("WATCHLIST_SCHEDULER", True):
-        return
-    _watchlist_thread_started = True
-    threading.Thread(target=_watchlist_scheduler_loop, daemon=True).start()
-
-def _send_webhook(url: str, payload: Dict[str, Any]) -> None:
-    from urllib.parse import urlparse
-    parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https") or not parsed.hostname:
-        return
-    try:
-        _resolve_all_public(parsed.hostname)
-    except ValueError as e:
-        msg = str(e)
-        if "cannot be resolved" not in msg and "did not resolve" not in msg:
-            return
-
-    webhook_format = os.environ.get("WEBHOOK_FORMAT", "raw")
-    if webhook_format == "slack":
-        payload = format_slack(payload)
-    elif webhook_format == "discord":
-        payload = format_discord(payload)
-
-    headers = {"Content-Type": "application/json", "User-Agent": "PRISM-Webhook/2.1.2"}
-    if WEBHOOK_SECRET:
-        headers["X-Prism-Secret"] = WEBHOOK_SECRET
-    try:
-        _requests.post(
-            url, json=payload, headers=headers,
-            timeout=10, allow_redirects=False,
-        )
-    except TypeError:
-        try:
-            _requests.post(
-                url, json=payload, headers=headers,
-                timeout=10,
-            )
-        except Exception:
-            pass
-    except Exception:
-        pass
-
-def _detect_type(target: str) -> str:
-    if "@" in target:
-        return "email"
-    parts = target.replace("+", "").replace("-", "").replace(" ", "")
-    if parts.isdigit():
-        return "phone"
-    t = target.lstrip("@")
-    if t.startswith("t.me/") or t.startswith("telegram.me/"):
-        return "telegram"
-    if "." in target:
-        segs = target.split(".")
-        if len(segs) == 4 and all(s.isdigit() for s in segs):
-            return "ip"
-        return "domain"
-    return "username"
-
-async def _push(scan_id: str, msg: Dict) -> None:
-    scan = _scans.get(scan_id)
-    if scan is not None:
-        if "progress" not in scan:
-            scan["progress"] = []
-        scan["progress"].append(msg)
-        _save_scan(scan_id, scan)
-    q = _queues.get(scan_id)
-    if q:
-        await q.put(msg)
-
-_CACHED_MODULES = {"shodan", "hlr", "virustotal", "abuseipdb", "geoip"}
-
-def _done_message(name: str, result: Any, cached: bool = False) -> Dict[str, Any]:
-    status = classify(result)
-    msg: Dict[str, Any] = {"type": "module_done", "module": name, "status": status}
-    if cached:
-        msg["cached"] = True
-    reason = reason_for(result)
-    if reason and status != OK:
-        msg["reason"] = reason
-        if status == ERROR:
-            msg["error"] = reason
-    return msg
-
-
-async def _run_module(scan_id: str, name: str, coro_or_func, *args, **kwargs) -> Any:
-    await _push(scan_id, {"type": "module_start", "module": name})
-    cache_target = args[0] if args else None
-    force_refresh = bool(_scans.get(scan_id, {}).get("force_refresh"))
-    if not force_refresh and name in _CACHED_MODULES and cache_target:
-        cached = _get_cached(name, str(cache_target))
-        # Ignore legacy non-OK cache entries so the module can re-run.
-        if cached is not None and classify(cached) == OK:
-            await _push(scan_id, _done_message(name, cached, cached=True))
-            return cached
-    try:
-        if asyncio.iscoroutinefunction(coro_or_func):
-            result = await coro_or_func(*args, **kwargs)
-        else:
-            loop = asyncio.get_event_loop()
-            result = await loop.run_in_executor(None, lambda: coro_or_func(*args, **kwargs))
-        status = classify(result)
-        if isinstance(result, dict) and "status" not in result:
-            result["status"] = status
-        # Cache only successful results so a missing key is not frozen in cache.
-        if name in _CACHED_MODULES and cache_target and status == OK:
-            _set_cache(name, str(cache_target), result)
-        await _push(scan_id, _done_message(name, result))
-        return result
-    except Exception as exc:
-        await _push(scan_id, {"type": "module_done", "module": name, "status": ERROR, "error": str(exc)})
-        return {"error": str(exc), "status": ERROR}
-
-async def _execute_scan(scan_id: str, target: str, scan_type: str, modules: list, webhook_url: Optional[str] = None) -> None:
-    results: Dict[str, Any] = {}
-    all_modules = not modules
-
-    def want(name: str) -> bool:
-        return all_modules or name in modules
-
-    try:
-        if scan_type in ("domain", "ip"):
-            if want("whois") and scan_type == "domain":
-                from modules.extra_tools import WhoisLookup
-                results["whois"] = await _run_module(scan_id, "whois", WhoisLookup().lookup, target)
-
-            if want("dns") and scan_type == "domain":
-                from modules.extra_tools import DNSLookup
-                results["dns"] = await _run_module(scan_id, "dns", DNSLookup().lookup, target)
-
-            if want("geoip"):
-                from modules.extra_tools import GeoIPLookup
-                results["geoip"] = await _run_module(scan_id, "geoip", GeoIPLookup().lookup, target)
-
-            if want("cert_transparency") and scan_type == "domain":
-                from modules.cert_transparency import CertTransparency
-                results["cert_transparency"] = await _run_module(
-                    scan_id, "cert_transparency", CertTransparency().search, target
-                )
-
-            if want("website") and scan_type == "domain":
-                from modules.extra_tools import WebsiteAnalyzer
-                results["website"] = await _run_module(
-                    scan_id, "website", WebsiteAnalyzer().analyze, target
-                )
-
-            if want("wayback") and scan_type == "domain":
-                                                                            
-                                                                              
-                                                                            
-                                                            
-                from modules.wayback import WaybackMachine
-                wb = WaybackMachine()
-                wayback_snap = await _run_module(
-                    scan_id, "wayback", wb.get_snapshots, target, 15
-                )
-                wayback_urls = await _run_module(
-                    scan_id, "wayback_urls", wb.get_all_urls, target, 200
-                )
-                merged = dict(wayback_snap) if isinstance(wayback_snap, dict) else {}
-                if isinstance(wayback_urls, dict):
-                    merged["urls"] = wayback_urls.get("urls", [])
-                    merged["total_urls"] = wayback_urls.get("total", 0)
-                    merged["interesting"] = wayback_urls.get("interesting", [])
-                                                                          
-                                                                           
-                    if wayback_urls.get("error") and not merged.get("error"):
-                        merged["urls_error"] = wayback_urls["error"]
-                results["wayback"] = merged
-
-            if want("shodan"):
-                from modules.shodan_lookup import ShodanLookup
-                ip = target
-                if scan_type == "domain":
-                    import socket
-                    try:
-                        ip = socket.gethostbyname(target)
-                    except Exception:
-                        ip = target
-                results["shodan"] = await _run_module(scan_id, "shodan", ShodanLookup().host_info, ip)
-
-            if want("virustotal"):
-                from modules.threat_intel import VirusTotal
-                vt = VirusTotal()
-                if scan_type == "ip":
-                    results["virustotal"] = await _run_module(scan_id, "virustotal", vt.check_ip, target)
-                else:
-                    results["virustotal"] = await _run_module(scan_id, "virustotal", vt.check_domain, target)
-
-            if want("abuseipdb") and scan_type == "ip":
-                from modules.threat_intel import AbuseIPDB
-                results["abuseipdb"] = await _run_module(scan_id, "abuseipdb", AbuseIPDB().check_ip, target)
-
-            if want("onion") and scan_type == "domain":
-                from modules.onion_checker import OnionChecker
-                results["onion"] = await _run_module(scan_id, "onion", OnionChecker().check, target)
-
-            if want("censys"):
-                from modules.censys_lookup import CensysLookup
-                cl = CensysLookup()
-                if scan_type == "domain":
-                    results["censys"] = await _run_module(scan_id, "censys", cl.search_domain, target)
-                else:
-                    results["censys"] = await _run_module(scan_id, "censys", cl.search_ip, target)
-
-            if want("hudsonrock") and scan_type == "domain":
-                from modules.hudsonrock import HudsonRockLookup
-                results["hudsonrock"] = await _run_module(
-                    scan_id, "hudsonrock", HudsonRockLookup().search_domain, target
-                )
-
-            if want("lunar") and scan_type == "domain":
-                from modules.lunar import LunarLookup
-                results["lunar"] = await _run_module(
-                    scan_id, "lunar", LunarLookup().search_domain, target
-                )
-
-        elif scan_type == "email":
-            if want("smtp"):
-                from modules.smtp_verify import SMTPVerifier
-                results["smtp"] = await _run_module(scan_id, "smtp", SMTPVerifier().verify_email, target)
-
-            if want("leaks"):
-                from modules.leak_lookup import LeakLookup
-                results["breaches"] = await _run_module(
-                    scan_id, "leaks", LeakLookup().check_email_full, target
-                )
-
-            if want("emailrep"):
-                from modules.hunter import EmailRepLookup
-                results["emailrep"] = await _run_module(
-                    scan_id, "emailrep", EmailRepLookup().lookup, target
-                )
-            
-            if want("gravatar"):
-                from modules.gravatar import GravatarRecon
-                results["gravatar"] = await _run_module(
-                    scan_id, "gravatar", GravatarRecon().lookup, target
-                )
-
-            if want("hudsonrock"):
-                from modules.hudsonrock import HudsonRockLookup
-                results["hudsonrock"] = await _run_module(
-                    scan_id, "hudsonrock", HudsonRockLookup().search_email, target
-                )
-
-        elif scan_type == "phone":
-            if want("hlr"):
-                from modules.hlr_lookup import HLRLookup
-                hlr_obj = HLRLookup()
-                hlr = await _run_module(scan_id, "hlr", hlr_obj.validate_phone, target)
-                results["hlr"] = hlr
-                owner = await _run_module(
-                    scan_id, "phone_owner", hlr_obj.reverse_lookup,
-                    hlr.get("formatted") or target
-                )
-                results["phone_owner"] = owner
-                results["phone"] = {
-                    "valid": hlr.get("valid"),
-                    "country_name": hlr.get("country_name") or hlr.get("country"),
-                    "country_code": hlr.get("country_code"),
-                    "carrier": hlr.get("carrier"),
-                    "line_type": hlr.get("line_type"),
-                    "region": hlr.get("region"),
-                    "timezones": hlr.get("timezones"),
-                    "reverse": {
-                        "name": ", ".join(owner.get("names", [])) or None,
-                        "address": owner.get("city"),
-                        "source": ", ".join(owner.get("sources", [])) or None,
-                    } if owner else None,
-                }
-
-        elif scan_type == "telegram":
-            from modules.telegram_lookup import TelegramLookup
-            from config import TELEGRAM_BOT_TOKEN
-            tg = TelegramLookup()
-            tg_target = target.lstrip("@").replace("t.me/", "").replace("telegram.me/", "").strip()
-            results["telegram"] = await _run_module(
-                scan_id, "telegram", tg.run_lookup, tg_target, TELEGRAM_BOT_TOKEN or None
-            )
-
-        elif scan_type == "username":
-            if want("blackbird"):
-                from modules.blackbird import Blackbird
-                bb = Blackbird(timeout=10, max_concurrent=25)
-                outcome = await _run_module(scan_id, "blackbird", bb.search, target)
-                if isinstance(outcome, dict) and outcome.get("error"):
-                    results["blackbird"] = outcome
-                else:
-                    results["blackbird"] = [
-                        {"site": r.site, "url": r.url, "status": r.status, "response_time": r.response_time}
-                        for r in bb.results
-                    ]
-
-            if want("maigret"):
-                from modules.maigret_wrapper import MaigretWrapper
-                results["maigret"] = await _run_module(
-                    scan_id, "maigret", MaigretWrapper().search, target
-                )
-
-            if want("github"):
-                from modules.github_recon import GitHubRecon
-                results["github"] = await _run_module(
-                    scan_id, "github", GitHubRecon().lookup, target
-                )
-
-            if want("hudsonrock"):
-                from modules.hudsonrock import HudsonRockLookup
-                results["hudsonrock"] = await _run_module(
-                    scan_id, "hudsonrock", HudsonRockLookup().search_username, target
-                )
-
-        await _push(scan_id, {"type": "module_start", "module": "opsec_score"})
-        opsec = score_from_results(results)
-        results["opsec_score"] = opsec
-        await _push(scan_id, {"type": "module_done", "module": "opsec_score", "status": OK})
-
-        graph = build_graph(target, scan_type, results)
-        results["graph"] = graph
-
-        report_path = generate_html_report(target, scan_type, results, opsec)
-        results["report_path"] = report_path
-
-        _scans[scan_id].update(
-            {
-                "status": "completed",
-                "results": results,
-                "completed_at": datetime.now().isoformat(),
-            }
-        )
-        _save_scan(scan_id, _scans[scan_id])
-        await _push(scan_id, {"type": "scan_complete", "scan_id": scan_id})
-
-    except Exception as exc:
-        safe_err = str(exc).split("\n")[0][:200]
-        _scans[scan_id].update({"status": "error", "error": safe_err})
-        _save_scan(scan_id, _scans[scan_id])
-        await _push(scan_id, {"type": "scan_error", "error": safe_err})
-    finally:
-        await _push(scan_id, {"type": "_done"})
-        if webhook_url:
-            scan_snapshot = _scans.get(scan_id, {})
-            payload = {
-                "scan_id": scan_id,
+# Disable docs if configured
+if DISABLE_DOCS:
+    app.docs_url = None
+    app.redoc_url = None
+
+# Static files for frontend
+frontend_dir = PRISM_FRONTEND_DIR or os.path.join(os.path.dirname(os.path.dirname(__file__)), "frontend", "out")
+if os.path.exists(frontend_dir):
+    app.mount("/_next", StaticFiles(directory=os.path.join(frontend_dir, "_next")), name="_next")
+    app.mount("/static", StaticFiles(directory=os.path.join(frontend_dir, "static")), name="static")
+
+
+# Scan state management
+class ScanState:
+    def __init__(self):
+        self.scans: Dict[str, Dict[str, Any]] = {}
+        self.lock = asyncio.Lock()
+
+    async def create(self, target: str, scan_type: str, principal: str) -> str:
+        scan_id = str(uuid.uuid4())
+        async with self.lock:
+            self.scans[scan_id] = {
+                "id": scan_id,
                 "target": target,
                 "scan_type": scan_type,
-                "status": scan_snapshot.get("status"),
-                "started_at": scan_snapshot.get("started_at"),
-                "completed_at": scan_snapshot.get("completed_at"),
-                "error": scan_snapshot.get("error"),
-                "results": {
-                    k: v for k, v in (scan_snapshot.get("results") or {}).items()
-                    if k not in ("graph", "report_path")
-                },
+                "principal": principal,
+                "status": "pending",
+                "started_at": datetime.now().isoformat(),
+                "completed_at": None,
+                "results": {},
+                "log": [],
+                "module_status": {},
             }
-            threading.Thread(target=_send_webhook, args=(webhook_url, payload), daemon=True).start()
+            # Clean up old scans
+            self._cleanup()
+        return scan_id
 
-@app.get("/healthz", include_in_schema=False)
+    async def update(self, scan_id: str, data: Dict[str, Any]) -> None:
+        async with self.lock:
+            if scan_id in self.scans:
+                self.scans[scan_id].update(data)
+
+    async def add_log(self, scan_id: str, message: str) -> None:
+        async with self.lock:
+            if scan_id in self.scans:
+                self.scans[scan_id]["log"].append(message)
+
+    async def get(self, scan_id: str, principal: str) -> Optional[Dict[str, Any]]:
+        async with self.lock:
+            scan = self.scans.get(scan_id)
+            if scan and scan.get("principal") == principal:
+                # Return a copy without sensitive data
+                return {k: v for k, v in scan.items() if k != "principal"}
+            return None
+
+    async def list_scans(self, principal: str, limit: int = 20) -> List[Dict[str, Any]]:
+        async with self.lock:
+            scans = [v for v in self.scans.values() if v.get("principal") == principal]
+            scans.sort(key=lambda x: x.get("started_at", ""), reverse=True)
+            return [{k: v for k, v in s.items() if k != "principal"} for s in scans[:limit]]
+
+    def _cleanup(self):
+        """Remove old scans beyond MAX_STORED_SCANS."""
+        if len(self.scans) > MAX_STORED_SCANS * 2:
+            # Sort by started_at and remove oldest
+            items = sorted(
+                [(k, v) for k, v in self.scans.items()],
+                key=lambda x: x[1].get("started_at", ""),
+                reverse=True,
+            )
+            keep = {k: v for k, v in items[:MAX_STORED_SCANS]}
+            self.scans.clear()
+            self.scans.update(keep)
+
+
+scan_state = ScanState()
+
+
+# WebSocket connection manager
+class ConnectionManager:
+    def __init__(self):
+        self.connections: Dict[str, WebSocket] = {}
+
+    async def connect(self, scan_id: str, websocket: WebSocket):
+        await websocket.accept()
+        self.connections[scan_id] = websocket
+
+    def disconnect(self, scan_id: str):
+        if scan_id in self.connections:
+            del self.connections[scan_id]
+
+    async def send(self, scan_id: str, message: Any):
+        if scan_id in self.connections:
+            try:
+                await self.connections[scan_id].send_json(message)
+            except Exception:
+                self.disconnect(scan_id)
+
+
+manager = ConnectionManager()
+
+
+# Helper functions
+def normalize_target(target: str) -> str:
+    """Normalize a target string."""
+    if not target:
+        return target
+    target = target.strip()
+    if target.startswith(("http://", "https://")):
+        target = target.split("://", 1)[1]
+    target = target.rstrip("/")
+    return target
+
+
+def detect_scan_type(target: str) -> str:
+    """Detect the type of target."""
+    target = target.strip()
+    import re
+
+    # Email
+    if "@" in target and "." in target.split("@")[-1]:
+        return "email"
+
+    # IPv4
+    if re.match(r"^(\d{1,3}\.){3}\d{1,3}$", target):
+        return "ip"
+
+    # IPv6 (simplified)
+    if re.match(r"^[0-9a-fA-F:]+:[0-9a-fA-F:]+$", target):
+        return "ip"
+
+    # Phone (simplified)
+    if re.match(r"^\+?[\d][\d\s().-]{6,}$", target):
+        return "phone"
+
+    # Username
+    if target.startswith("@"):
+        return "username"
+
+    # Domain
+    if "." in target and " " not in target:
+        return "domain"
+
+    return "username"
+
+
+async def run_scan_task(scan_id: str, target: str, scan_type: str, principal: str):
+    """Background task to run the scan."""
+    try:
+        await scan_state.update(scan_id, {"status": "running"})
+
+        # Start with the common modules
+        all_modules: Dict[str, Any] = {}
+
+        # Type-specific modules
+        if scan_type == "domain":
+            all_modules.update({
+                "whois": WhoisLookup,
+                "dns": DNSLookup,
+                "cert_transparency": CertTransparency,
+                "rdap": RDAPLookup,
+                "wayback": Wayback,
+            })
+            # GeoIP for domain too
+            all_modules["geoip"] = GeoIP
+            # Conditionally add keyed modules
+            if os.getenv("VIRUSTOTAL_API_KEY"):
+                all_modules["virustotal"] = VirusTotalLookup
+            if os.getenv("SHODAN_API_KEY"):
+                all_modules["shodan"] = ShodanLookup
+            if os.getenv("ABUSEIPDB_API_KEY"):
+                all_modules["abuseipdb"] = AbuseIPDBLookup
+
+        elif scan_type == "email":
+            all_modules.update({
+                "gravatar": GravatarRecon,
+                "breach": BreachCheck,
+            })
+
+        elif scan_type == "username":
+            all_modules.update({
+                "github": GitHubRecon,
+            })
+
+        elif scan_type == "ip":
+            all_modules["geoip"] = GeoIP
+            if os.getenv("VIRUSTOTAL_API_KEY"):
+                all_modules["virustotal"] = VirusTotalLookup
+            if os.getenv("SHODAN_API_KEY"):
+                all_modules["shodan"] = ShodanLookup
+            if os.getenv("ABUSEIPDB_API_KEY"):
+                all_modules["abuseipdb"] = AbuseIPDBLookup
+
+        elif scan_type == "phone":
+            pass  # No modules yet
+
+        # Dark web search for all types (if enabled)
+        # Only run for domain/username/email
+        if scan_type in ("domain", "username", "email"):
+            all_modules["darkweb"] = DarkWebSearch
+
+        # Onion checker for domain/email/username
+        if scan_type in ("domain", "email", "username"):
+            all_modules["onion"] = OnionChecker
+
+        total_modules = len(all_modules)
+        completed = 0
+
+        # Run each module
+        results: Dict[str, Any] = {}
+        module_status: Dict[str, str] = {}
+
+        for name, handler in all_modules.items():
+            await scan_state.add_log(scan_id, f"Running module: {name}")
+            await manager.send(scan_id, {"type": "module_start", "module": name})
+
+            try:
+                instance = handler()
+                if hasattr(instance, "lookup"):
+                    result = instance.lookup(target)
+                elif hasattr(instance, "search"):
+                    result = instance.search(target)
+                elif hasattr(instance, "check"):
+                    result = instance.check(target)
+                elif hasattr(instance, "run"):
+                    result = instance.run(target)
+                else:
+                    result = {"error": f"Module {name} has no main method"}
+
+                results[name] = result
+
+                # Determine status
+                if isinstance(result, dict):
+                    status = result.get("status")
+                    if status not in ("ok", "skipped", "rate_limited", "error"):
+                        if result.get("error"):
+                            status = "error"
+                        else:
+                            status = "ok"
+                else:
+                    status = "ok"
+
+                module_status[name] = status
+
+                # Update scan state
+                await scan_state.update(scan_id, {
+                    "results": results,
+                    "module_status": module_status,
+                })
+
+                # Send update
+                await manager.send(scan_id, {
+                    "type": "module_complete",
+                    "module": name,
+                    "status": status,
+                    "progress": {"completed": completed + 1, "total": total_modules},
+                })
+
+            except Exception as e:
+                results[name] = {"error": str(e)}
+                module_status[name] = "error"
+                await scan_state.add_log(scan_id, f"Error in {name}: {e}")
+                await manager.send(scan_id, {
+                    "type": "module_error",
+                    "module": name,
+                    "error": str(e),
+                })
+
+            completed += 1
+
+        # Run OPSEC scoring
+        try:
+            from modules.opsec_scorer import score_results
+            opsec_result = score_results(results)
+            results["opsec"] = opsec_result
+        except Exception as e:
+            results["opsec"] = {"error": str(e)}
+            await scan_state.add_log(scan_id, f"Error in OPSEC scoring: {e}")
+
+        # Update final state
+        await scan_state.update(scan_id, {
+            "status": "completed",
+            "completed_at": datetime.now().isoformat(),
+            "results": results,
+            "module_status": module_status,
+        })
+
+        await manager.send(scan_id, {"type": "complete", "results": results})
+
+        # Also update watchlist if this is a domain scan
+        if scan_type == "domain":
+            # This is a scan, not a watchlist run, but we might want to record it
+            pass
+
+    except Exception as e:
+        await scan_state.add_log(scan_id, f"Fatal error: {e}")
+        await scan_state.update(scan_id, {"status": "error"})
+        await manager.send(scan_id, {"type": "error", "error": str(e)})
+
+
+# Watchlist scheduler
+async def run_watchlist_scheduler():
+    """Background task to run watchlist scans."""
+    while True:
+        try:
+            due = due_watchlists()
+            for entry in due:
+                scan_id = await scan_state.create(entry["target"], "domain", f"watchlist-{entry['owner']}")
+                # Run the scan
+                asyncio.create_task(run_scan_task(scan_id, entry["target"], "domain", f"watchlist-{entry['owner']}"))
+                # Record the run in watchlist
+                # We need to wait for completion, but this is simplified
+                record_run(entry["id"], {})
+        except Exception as e:
+            print(f"Watchlist scheduler error: {e}")
+        await asyncio.sleep(60)
+
+
+# API Routes
+@app.get("/healthz")
 async def healthz():
     return {"status": "ok"}
 
-@app.get("/api/health")
-async def health():
-    return {"status": "ok", "version": app.version}
 
-@app.get("/api/usage", dependencies=[Depends(require_api_key)])
-@limiter.limit("60/minute")
-async def usage(request: Request):
-    return get_usage(get_principal(request))
+@app.post("/api/scan")
+async def start_scan(request: Request):
+    """Start a new scan."""
+    # Get principal from API key
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
 
-@app.post("/api/watchlist", dependencies=[Depends(require_api_key)])
-@limiter.limit("20/minute")
-async def create_watchlist_entry(request: Request, req: WatchlistRequest):
-    from web import watchlist
-    target = validate_target(req.target)
-    scan_type = req.scan_type if req.scan_type != "auto" else _detect_type(target)
-    validate_public_target(target, scan_type)
-    webhook_url = None
-    if req.webhook_url:
-        try:
-            webhook_url = _validate_webhook_url(req.webhook_url.strip())
-        except ValueError as e:
-            return JSONResponse({"error": str(e)}, status_code=400)
-    interval = max(1.0, min(float(req.interval_hours or 24.0), 24 * 30))
-    entry = watchlist.create_watchlist(
-        get_principal(request), target, scan_type, req.modules, interval, webhook_url,
-    )
-    return entry
-
-@app.get("/api/watchlist", dependencies=[Depends(require_api_key)])
-@limiter.limit("60/minute")
-async def list_watchlist(request: Request):
-    from web import watchlist
-    return {"watchlists": watchlist.list_watchlists(get_principal(request))}
-
-@app.get("/api/watchlist/{watch_id}/alerts", dependencies=[Depends(require_api_key)])
-@limiter.limit("60/minute")
-async def watchlist_alerts(request: Request, watch_id: str):
-    from web import watchlist
-    validate_scan_id(watch_id)
-    entry = watchlist.get_watchlist(watch_id)
-    if not entry or (entry.get("owner") or ANONYMOUS_PRINCIPAL) != get_principal(request):
-        return JSONResponse({"error": "Watchlist not found"}, status_code=404)
-    return {"id": watch_id, "alerts": entry.get("alerts", [])}
-
-@app.delete("/api/watchlist/{watch_id}", dependencies=[Depends(require_api_key)])
-@limiter.limit("30/minute")
-async def delete_watchlist_entry(request: Request, watch_id: str):
-    from web import watchlist
-    validate_scan_id(watch_id)
-    if not watchlist.delete_watchlist(watch_id, get_principal(request)):
-        return JSONResponse({"error": "Watchlist not found"}, status_code=404)
-    return {"deleted": watch_id}
-
-@app.patch("/api/watchlist/{watch_id}", dependencies=[Depends(require_api_key)])
-@limiter.limit("30/minute")
-async def patch_watchlist_entry(request: Request, watch_id: str, req: WatchlistPatchRequest):
-    from web import watchlist
-    validate_scan_id(watch_id)
-    entry = watchlist.set_paused(watch_id, get_principal(request), req.paused)
-    if entry is None:
-        return JSONResponse({"error": "Watchlist not found"}, status_code=404)
-    return entry
-
-class TestWebhookRequest(BaseModel):
-    webhook_url: str
-
-@app.post("/api/watchlist/test-webhook", dependencies=[Depends(require_api_key)])
-@limiter.limit("10/minute")
-async def test_webhook(request: Request, req: TestWebhookRequest):
+    # Get request body
     try:
-        url = _validate_webhook_url(req.webhook_url.strip())
-    except ValueError as e:
-        return JSONResponse({"error": str(e)}, status_code=400)
-    payload = {
-        "event": "watchlist_test",
-        "message": "This is a test webhook from Prism.",
-        "target": "example.com",
-        "scan_type": "domain",
-        "added": 1,
-        "removed": 0,
-        "changes": ["+test.example.com"],
-    }
+        body = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
+    target = body.get("target", "").strip()
+    scan_type = body.get("type") or detect_scan_type(target)
+
+    if not target:
+        raise HTTPException(status_code=400, detail="Target is required")
+
+    # Normalize target
+    target = normalize_target(target)
+
+    # Validate target is public (if configured)
     try:
-        _send_webhook(url, payload)
-    except Exception as e:
-        return JSONResponse({"error": f"Webhook delivery failed: {e}"}, status_code=502)
-    return {"ok": True, "url": url}
+        validate_public_target(target, scan_type)
+    except HTTPException as e:
+        raise e
 
-@app.post("/api/scan", dependencies=[Depends(require_api_key)])
-@limiter.limit("10/minute")
-async def start_scan(request: Request, req: ScanRequest):
-    target = validate_target(req.target)
+    # Check scan quota
+    try:
+        check_scan_quota(principal)
+    except HTTPException as e:
+        raise e
 
-    webhook_url = None
-    if req.webhook_url:
-        try:
-            webhook_url = _validate_webhook_url(req.webhook_url.strip())
-        except ValueError as e:
-            return JSONResponse({"error": str(e)}, status_code=400)
+    # Create scan
+    scan_id = await scan_state.create(target, scan_type, principal)
 
-    scan_type = req.scan_type if req.scan_type != "auto" else _detect_type(target)
-    validate_public_target(target, scan_type)
-
-    principal = get_principal(request)
-    check_scan_quota(principal)
+    # Record the scan for quota
     record_scan(principal)
 
-    scan_id = str(uuid.uuid4())
+    # Start the scan in the background
+    asyncio.create_task(run_scan_task(scan_id, target, scan_type, principal))
 
-    _evict_old_scans()
-    _scans[scan_id] = {
-        "scan_id": scan_id,
-        "target": target,
-        "scan_type": scan_type,
-        "status": "running",
-        "started_at": datetime.now().isoformat(),
-        "owner": get_principal(request),
-        "results": None,
-        "progress": [],
-        "modules": req.modules,
-        "force_refresh": req.force_refresh,
-    }
-    _save_scan(scan_id, _scans[scan_id])
-    _queues[scan_id] = asyncio.Queue()
-
-    def _run_in_thread():
-        loop = asyncio.new_event_loop()
-        asyncio.set_event_loop(loop)
-        try:
-            loop.run_until_complete(_execute_scan(scan_id, target, scan_type, req.modules, webhook_url))
-        finally:
-            loop.close()
-
-    threading.Thread(target=_run_in_thread, daemon=True).start()
-
-    return {"scan_id": scan_id, "scan_type": scan_type}
-
-@app.get("/api/scan/{scan_id}", dependencies=[Depends(require_api_key)])
-@limiter.limit("30/minute")
-async def get_scan(request: Request, scan_id: str):
-    validate_scan_id(scan_id)
-    scan = _load_scan(scan_id)
-    if not scan or not _scan_visible_to(scan, get_principal(request)):
-        return JSONResponse({"error": "Scan not found"}, status_code=404)
-    safe = {k: v for k, v in scan.items() if k not in ("results", "owner")}
-    if scan.get("results"):
-        res_copy = {k: v for k, v in scan["results"].items() if k not in ("graph", "report_path")}
-        safe["results"] = res_copy
-    safe["progress"] = scan.get("progress", [])
-    return safe
-
-@app.get("/api/scan/{scan_id}/graph", dependencies=[Depends(require_api_key)])
-@limiter.limit("30/minute")
-async def get_graph(request: Request, scan_id: str):
-    validate_scan_id(scan_id)
-    scan = _load_scan(scan_id)
-    if not scan or not _scan_visible_to(scan, get_principal(request)) or not scan.get("results"):
-        return JSONResponse({"error": "Scan not found or not completed"}, status_code=404)
-    return scan["results"].get("graph", {"nodes": [], "edges": []})
-
-
-@app.get("/api/scan/{scan_id}/graph/export", dependencies=[Depends(require_api_key)])
-@limiter.limit("30/minute")
-async def export_graph(request: Request, scan_id: str, fmt: str = "graphml"):
-    validate_scan_id(scan_id)
-    scan = _load_scan(scan_id)
-    if not scan or not _scan_visible_to(scan, get_principal(request)) or not scan.get("results"):
-        return JSONResponse({"error": "Scan not found or not completed"}, status_code=404)
-    graph = scan["results"].get("graph", {"nodes": [], "edges": []})
-    fmt = (fmt or "graphml").lower()
-    from modules.graph_export import to_graphml, to_gexf
-    if fmt == "gexf":
-        body, media, ext = to_gexf(graph), "application/gexf+xml", "gexf"
-    elif fmt == "graphml":
-        body, media, ext = to_graphml(graph), "application/graphml+xml", "graphml"
-    else:
-        return JSONResponse({"error": "Unsupported format. Use graphml or gexf."}, status_code=400)
-    filename = f"prism_{scan_id[:8]}.{ext}"
-    return Response(
-        content=body,
-        media_type=media,
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-    )
-
-@app.get("/api/scan/{scan_id}/map", dependencies=[Depends(require_api_key)])
-@limiter.limit("30/minute")
-async def get_map_data(request: Request, scan_id: str):
-    validate_scan_id(scan_id)
-    scan = _load_scan(scan_id)
-    if not scan or not _scan_visible_to(scan, get_principal(request)) or not scan.get("results"):
-        return JSONResponse({"error": "Scan not found or not completed"}, status_code=404)
-
-    results = scan["results"]
-    markers = []
-
-    geoip = results.get("geoip", {})
-    if geoip and geoip.get("loc") and not geoip.get("error"):
-        try:
-            lat, lng = map(float, geoip["loc"].split(","))
-            markers.append({
-                "lat": lat, "lng": lng,
-                "ip": geoip.get("ip"),
-                "label": geoip.get("ip", scan["target"]),
-                "city": geoip.get("city"),
-                "region": geoip.get("region"),
-                "country": geoip.get("country_name") or geoip.get("country"),
-                "org": geoip.get("org"),
-                "timezone": geoip.get("timezone"),
-                "type": "host",
-            })
-        except (ValueError, AttributeError):
-            pass
-
-    shodan = results.get("shodan", {})
-    if shodan and not shodan.get("error"):
-        sloc = shodan.get("location", {})
-        if sloc and sloc.get("latitude") and sloc.get("longitude"):
-            lat, lng = sloc["latitude"], sloc["longitude"]
-            if not any(abs(m["lat"] - lat) < 0.01 and abs(m["lng"] - lng) < 0.01 for m in markers):
-                markers.append({
-                    "lat": lat, "lng": lng,
-                    "ip": shodan.get("ip_str"),
-                    "label": shodan.get("ip_str", scan["target"]),
-                    "city": sloc.get("city"),
-                    "region": sloc.get("region_code"),
-                    "country": sloc.get("country_name"),
-                    "org": shodan.get("org"),
-                    "type": "shodan",
-                })
-
-    hlr = results.get("hlr", {})
-    if hlr and not hlr.get("error"):
-        country_str = hlr.get("country_name") or hlr.get("country") or ""
-        region_str = hlr.get("location") or hlr.get("region") or ""
-        phone_label = hlr.get("formatted") or hlr.get("phone")
-        raw_lat = hlr.get("lat", hlr.get("latitude"))
-        raw_lng = hlr.get("lng", hlr.get("longitude"))
-        lat = None
-        lng = None
-        try:
-            if raw_lat is not None and raw_lng is not None:
-                lat = float(raw_lat)
-                lng = float(raw_lng)
-        except (TypeError, ValueError):
-            lat = None
-            lng = None
-
-        if lat is not None and lng is not None:
-            approx = bool(hlr.get("approximate", False))
-            markers.append({
-                "lat": lat, "lng": lng,
-                "ip": phone_label,
-                "label": phone_label,
-                "city": region_str or None,
-                "country": country_str or None,
-                "org": hlr.get("carrier"),
-                "timezone": (hlr.get("timezones") or [None])[0],
-                "type": "phone",
-                "valid": hlr.get("valid"),
-                "line_type": hlr.get("line_type"),
-                "approximate": approx,
-                "precision": hlr.get("precision") or ("approximate" if approx else "exact"),
-            })
-
-    center = markers[0] if markers else None
-    zoom = 5 if (markers and markers[0].get("type") == "phone") else None
-
-    info = None
-    if not markers:
-        hlr = results.get("hlr") or {}
-        phone = results.get("phone") or {}
-        country = hlr.get("country_name") or hlr.get("country") or phone.get("country_name")
-        carrier = hlr.get("carrier") or phone.get("carrier")
-        region = hlr.get("location") or hlr.get("region") or phone.get("region")
-        phone_label = hlr.get("formatted") or hlr.get("phone") or scan["target"]
-
-        place = None
-        if region or country:
-            place = _geocode_place(", ".join(p for p in (region, country) if p))
-
-        if place:
-            bbox = place.get("bbox")
-            if bbox:
-                clat, clng = (bbox[0] + bbox[1]) / 2, (bbox[2] + bbox[3]) / 2
-            else:
-                clat, clng = place["lat"], place["lng"]
-            markers.append({
-                "lat": clat, "lng": clng,
-                "bbox": bbox,
-                "ip": phone_label, "label": phone_label,
-                "city": region or None, "country": country or None,
-                "org": carrier, "type": "phone",
-                "approximate": True,
-                "precision": "region" if region else "country",
-            })
-            center = markers[0]
-            zoom = 7 if region else 4
-        elif country or carrier or region:
-            info = {
-                "reason": "Phone numbers don't expose precise GPS coordinates.",
-                "country": country or None,
-                "carrier": carrier or None,
-                "region": region or None,
-            }
-
-    return {"markers": markers, "center": center, "zoom": zoom, "info": info}
-
-def _normalize_lang(raw: Optional[str]) -> str:
-    from modules.report_i18n import SUPPORTED_LANGS
-    if not raw:
-        return "en"
-    key = raw.lower().split("-")[0].strip()
-    return key if key in SUPPORTED_LANGS else "en"
-
-@app.get("/api/scan/{scan_id}/report", dependencies=[Depends(require_api_key)])
-@limiter.limit("10/minute")
-async def download_report(request: Request, scan_id: str, lang: str = "en"):
-    validate_scan_id(scan_id)
-    scan = _load_scan(scan_id)
-    if not scan or not _scan_visible_to(scan, get_principal(request)) or not scan.get("results"):
-        return JSONResponse({"error": "Scan not found or not completed"}, status_code=404)
-    results = scan["results"]
-    opsec = results.get("opsec_score")
-    lang = _normalize_lang(lang)
-    loop = asyncio.get_event_loop()
-    report_path = await loop.run_in_executor(
-        None,
-        lambda: generate_html_report(scan["target"], scan["scan_type"], results, opsec, lang=lang),
-    )
-    scan["results"]["report_path"] = report_path
-    return FileResponse(
-        report_path,
-        media_type="text/html",
-        filename=os.path.basename(report_path),
-    )
-
-@app.get("/api/scan/{scan_id}/report/pdf", dependencies=[Depends(require_api_key)])
-@limiter.limit("5/minute")
-async def download_report_pdf(request: Request, scan_id: str, lang: str = "en"):
-    validate_scan_id(scan_id)
-    scan = _load_scan(scan_id)
-    if not scan or not _scan_visible_to(scan, get_principal(request)) or not scan.get("results"):
-        return JSONResponse({"error": "Scan not found or not completed"}, status_code=404)
-    results = scan["results"]
-    opsec = results.get("opsec_score")
-    lang = _normalize_lang(lang)
-    loop = asyncio.get_event_loop()
-    try:
-        pdf_path = await loop.run_in_executor(
-            None,
-            lambda: generate_pdf_report(scan["target"], scan["scan_type"], results, opsec, lang=lang),
-        )
-    except ImportError as e:
-        return JSONResponse({"error": str(e)}, status_code=501)
-    except Exception as e:
-        return JSONResponse({"error": f"PDF generation failed: {str(e)[:200]}"}, status_code=500)
-    return FileResponse(
-        pdf_path,
-        media_type="application/pdf",
-        filename=os.path.basename(pdf_path),
-    )
-
-@app.post("/api/url-scan", dependencies=[Depends(require_api_key)])
-@limiter.limit("20/minute")
-async def scan_url(request: Request, req: dict):
-    url = req.get("url", "").strip()
-    if not url or len(url) > 2048:
-        return JSONResponse({"error": "No URL provided or URL too long"}, status_code=400)
-    if not url.startswith(("http://", "https://")):
-        url = "https://" + url
-    validate_url_not_private(url)
-    from modules.url_scanner import URLScanner
-    loop = asyncio.get_event_loop()
-    result = await loop.run_in_executor(None, URLScanner().scan, url)
-    return result
-
-_OUI_DATA: Optional[Dict[str, str]] = None
-
-def _get_oui_data() -> Dict[str, str]:
-    global _OUI_DATA
-    if _OUI_DATA is None:
-        oui_path = os.path.join(os.path.dirname(__file__), "oui_data.json")
-        try:
-            with open(oui_path, "r", encoding="utf-8") as f:
-                _OUI_DATA = json.load(f)
-        except Exception:
-            _OUI_DATA = {}
-    return _OUI_DATA
-
-def _lookup_local_oui(mac: str) -> Optional[str]:
-    oui_data = _get_oui_data()
-    prefix = mac.upper().replace("-", ":")
-    first_three = ":".join(prefix.split(":")[:3])
-    return oui_data.get(first_three)
-
-@app.post("/api/mac-lookup", dependencies=[Depends(require_api_key)])
-@limiter.limit("20/minute")
-async def mac_lookup(request: Request, req: dict):
-    mac = req.get("mac", "").strip()
-    if not mac or len(mac) > 17:
-        return JSONResponse({"error": "No MAC address provided or format too long"}, status_code=400)
-    mac_pattern = re.compile(r'^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$')
-    if not mac_pattern.match(mac):
-        return JSONResponse({"error": "Invalid MAC address format. Expected: 00:00:5e:00:53:af"}, status_code=400)
-
-    normalized_mac = mac.upper().replace("-", ":")
-    cached = _get_cached("mac", normalized_mac)
-    if cached:
-        return cached
-
-    vendor = _lookup_local_oui(normalized_mac)
-    if vendor:
-        result = {"mac": normalized_mac, "vendor": vendor, "source": "local"}
-        _set_cache("mac", normalized_mac, result)
-        return result
-
-    try:
-        loop = asyncio.get_event_loop()
-        def _fetch():
-            resp = _requests.get(f"https://api.macvendors.com/{mac}", timeout=10)
-            if resp.status_code == 200:
-                return {"mac": normalized_mac, "vendor": resp.text.strip(), "source": "api"}
-            elif resp.status_code == 404:
-                return {"mac": normalized_mac, "vendor": None, "error": "Not found", "source": "api"}
-            else:
-                return {"mac": normalized_mac, "vendor": None, "error": f"API returned status {resp.status_code}", "source": "api"}
-        result = await loop.run_in_executor(None, _fetch)
-        if result.get("vendor") and not result.get("error"):
-            _set_cache("mac", normalized_mac, result)
-        return result
-    except Exception as e:
-        local_vendor = _lookup_local_oui(normalized_mac)
-        if local_vendor:
-            result = {"mac": normalized_mac, "vendor": local_vendor, "source": "local_fallback"}
-            _set_cache("mac", normalized_mac, result)
-            return result
-        return JSONResponse({"error": str(e), "mac": normalized_mac, "vendor": None}, status_code=500)
-
-@app.post("/api/crypto", dependencies=[Depends(require_api_key)])
-@limiter.limit("20/minute")
-async def crypto_lookup(request: Request, req: dict):
-    address = req.get("address", "").strip()
-    if not address or len(address) > 256:
-        return JSONResponse({"error": "No address provided or address too long"}, status_code=400)
-    from modules.crypto_lookup import CryptoLookup
-    loop = asyncio.get_event_loop()
-    result = await loop.run_in_executor(None, CryptoLookup().lookup, address)
-    return result
-
-@app.post("/api/darkweb", dependencies=[Depends(require_api_key)])
-@limiter.limit("10/minute")
-async def darkweb_search(request: Request, req: dict):
-    query = req.get("query", "").strip()
-    if not query or len(query) > 512:
-        return JSONResponse({"error": "No query provided or query too long"}, status_code=400)
-    from modules.darkweb_search import DarkWebSearch
-    loop = asyncio.get_event_loop()
-    result = await loop.run_in_executor(None, DarkWebSearch().search, query)
-    return result
-
-@app.post("/api/qr-decode", dependencies=[Depends(require_api_key), Depends(check_upload_size)])
-@limiter.limit("20/minute")
-async def decode_qr(request: Request, file: UploadFile = File(...)):
-    from web.security import MAX_UPLOAD_BYTES
-    data = await file.read(MAX_UPLOAD_BYTES + 1)
-    if len(data) > MAX_UPLOAD_BYTES:
-        return JSONResponse({"error": "File too large"}, status_code=413)
-    from modules.qr_decoder import QRDecoder
-    loop = asyncio.get_event_loop()
-    result = await loop.run_in_executor(None, QRDecoder().decode, data, file.filename)
-    return result
-
-@app.post("/api/email-headers", dependencies=[Depends(require_api_key)])
-@limiter.limit("20/minute")
-async def analyze_email_headers(request: Request, req: dict):
-    raw = req.get("headers", "").strip()
-    if not raw or len(raw) > 50000:
-        return JSONResponse({"error": "No headers provided or input too large"}, status_code=400)
-    from modules.email_header_analyzer import analyze_headers
-    loop = asyncio.get_event_loop()
-    result = await loop.run_in_executor(None, analyze_headers, raw)
-    return result
-
-@app.post("/api/metadata", dependencies=[Depends(require_api_key), Depends(check_upload_size)])
-@limiter.limit("20/minute")
-async def extract_metadata_endpoint(request: Request, file: UploadFile = File(...)):
-    import tempfile, shutil
-    ALLOWED_EXTS = {".jpg", ".jpeg", ".png", ".tiff", ".tif", ".heic", ".heif", ".webp", ".pdf", ".docx", ".docm"}
-    suffix = os.path.splitext(file.filename or "")[1].lower()
-    if suffix not in ALLOWED_EXTS:
-        return JSONResponse({"error": f"Unsupported file type: {suffix}"}, status_code=400)
-    with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as tmp:
-        shutil.copyfileobj(file.file, tmp)
-        tmp_path = tmp.name
-    try:
-        from modules.metadata_extractor import extract_metadata
-        loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(None, extract_metadata, tmp_path)
-        result["filename"] = file.filename
-        result["file_type"] = result.pop("format", None)
-        result["file_size"] = result.pop("size_bytes", None)
-        result["exif"] = result.pop("raw_exif", {})
-        return result
-    finally:
-        try:
-            os.unlink(tmp_path)
-        except Exception:
-            pass
-
-def _llm_error_message(err) -> str:
-    if isinstance(err, dict):
-        return str(err.get("message") or err.get("code") or err)
-    return str(err)
-
-
-_LLM_BLOCKED_HINTS = (
-    "access denied",
-    "security policy",
-    "unavailable in your",
-    "not available in your",
-    "region",
-    "country",
-    "forbidden",
-    "cloudflare",
-)
-
-
-def _looks_geo_blocked(message: str) -> bool:
-    low = (message or "").lower()
-    return any(hint in low for hint in _LLM_BLOCKED_HINTS)
-
-
-def _call_llm(provider: Dict[str, str], payload: Dict[str, Any]) -> Dict[str, Any]:
-    body = dict(payload)
-    body["model"] = provider["model"]
-    try:
-        r = _requests.post(
-            provider["url"],
-            headers={"Authorization": f"Bearer {provider['key']}", "Content-Type": "application/json",
-                     "HTTP-Referer": "https://getprism.su", "X-Title": "PRISM OSINT"},
-            json=body,
-            timeout=30,
-            proxies=_LLM_PROXIES,
-        )
-    except Exception as e:
-        return {"error": f"{provider['name']} could not be reached: {str(e)[:150]}"}
-    try:
-        data = r.json()
-    except ValueError:
-        return {"error": f"HTTP {r.status_code} from {provider['name']}: {r.text[:200]}"}
-    if not isinstance(data, dict):
-        return {"error": f"Unexpected response from {provider['name']}: {str(data)[:200]}"}
-    return data
-
-
-def _llm_complete(payload: Dict[str, Any]) -> Dict[str, Any]:
-    providers = llm_providers()
-    if not providers:
-        return {"error": "No LLM provider configured. Set LLM_API_KEY, OPENROUTER_API_KEY or GROQ_API_KEY in .env."}
-
-    attempts = []
-    for provider in providers:
-        data = _call_llm(provider, payload)
-        if data.get("choices"):
-            return {"text": data["choices"][0]["message"]["content"],
-                    "model": data.get("model") or provider["model"],
-                    "provider": provider["name"]}
-        message = _llm_error_message(data.get("error")) if data.get("error") else f"no choices returned by {provider['name']}"
-        attempts.append(f"{provider['name']}: {message}")
-
-    if len(attempts) == 1:
-        return {"error": attempts[0].split(": ", 1)[-1], "tried": attempts}
-    blocked = [a for a in attempts if _looks_geo_blocked(a)]
-    lead = "Every configured LLM provider refused the request."
-    if blocked:
-        lead += " Providers commonly reject traffic from datacentre regions at their edge."
-    return {"error": lead + " " + "; ".join(attempts), "tried": attempts}
-
-@app.post("/api/ai/summary", dependencies=[Depends(require_api_key)])
-@limiter.limit("10/minute")
-async def ai_summary(request: Request, req: dict):
-    if not llm_providers():
-        return JSONResponse({"error": "No LLM provider configured. Set LLM_API_KEY, OPENROUTER_API_KEY or GROQ_API_KEY in .env."}, status_code=400)
-    scan_id = req.get("scan_id")
-    scan = _load_scan(scan_id) if scan_id else None
-    if not scan or not _scan_visible_to(scan, get_principal(request)) or not scan.get("results"):
-        return JSONResponse({"error": "Scan not found"}, status_code=404)
-
-    results = scan["results"]
-    summary_data = {k: v for k, v in results.items()
-                    if k not in ("graph", "report_path") and v and not (isinstance(v, dict) and v.get("error"))}
-
-    prompt = (
-        f"You are a professional OSINT analyst. Analyze the following reconnaissance results for target '{scan['target']}' "
-        f"(type: {scan['scan_type']}) and provide:\n"
-        "1. A concise executive summary (3-4 sentences)\n"
-        "2. Key findings (bullet points)\n"
-        "3. Risk assessment (Low/Medium/High with reasoning)\n"
-        "4. Recommended next investigation steps\n\n"
-        f"Data:\n{json.dumps(summary_data, indent=2, default=str)[:6000]}"
-    )
-
-    payload = {"messages": [{"role": "user", "content": prompt}], "temperature": 0.3, "max_tokens": 1024}
-    try:
-        loop = asyncio.get_event_loop()
-        outcome = await loop.run_in_executor(None, lambda: _llm_complete(payload))
-        if outcome.get("error"):
-            return JSONResponse({"error": outcome["error"], "tried": outcome.get("tried", [])}, status_code=400)
-        return {"summary": outcome["text"], "model": outcome["model"], "provider": outcome["provider"]}
-    except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
-
-@app.post("/api/ai/chat", dependencies=[Depends(require_api_key)])
-@limiter.limit("10/minute")
-async def ai_chat(request: Request, req: dict):
-    if not llm_providers():
-        return JSONResponse({"error": "No LLM provider configured. Set LLM_API_KEY, OPENROUTER_API_KEY or GROQ_API_KEY in .env."}, status_code=400)
-    scan_id = req.get("scan_id")
-    message = req.get("message", "").strip()
-    if not message:
-        return JSONResponse({"error": "No message provided"}, status_code=400)
-    scan = _load_scan(scan_id) if scan_id else None
-    if scan and not _scan_visible_to(scan, get_principal(request)):
-                                                                             
-        scan = None
-    context = ""
-    if scan and scan.get("results"):
-        results = scan["results"]
-        summary_data = {k: v for k, v in results.items()
-                        if k not in ("graph", "report_path") and v
-                        and not (isinstance(v, dict) and v.get("error"))}
-        context = (f"OSINT scan of '{scan['target']}' (type: {scan['scan_type']}):\n"
-                   f"{json.dumps(summary_data, indent=2, default=str)[:4000]}\n\n")
-    payload = {
-        "messages": [
-            {"role": "system", "content": (
-                "You are a professional OSINT analyst assistant. "
-                + (f"Context:\n{context}" if context else "Answer general OSINT questions concisely.")
-            )},
-            {"role": "user", "content": message},
-        ],
-        "temperature": 0.5,
-        "max_tokens": 512,
-    }
-    try:
-        loop = asyncio.get_event_loop()
-        outcome = await loop.run_in_executor(None, lambda: _llm_complete(payload))
-        if outcome.get("error"):
-            return JSONResponse({"error": outcome["error"], "tried": outcome.get("tried", [])}, status_code=400)
-        return {"reply": outcome["text"], "model": outcome["model"], "provider": outcome["provider"]}
-    except Exception as e:
-        return JSONResponse({"error": str(e)}, status_code=500)
-
-@app.get("/api/scans", dependencies=[Depends(require_api_key)])
-@limiter.limit("30/minute")
-async def list_scans(request: Request):
-    all_scans = _list_scans_from_disk(principal=get_principal(request))
-    return [
-        {
-            "scan_id": s.get("scan_id", ""),
-            "target": s.get("target", ""),
-            "scan_type": s.get("scan_type", ""),
-            "status": s.get("status", ""),
-            "started_at": s.get("started_at", ""),
-        }
-        for s in all_scans
-    ]
-
-@app.delete("/api/scans", dependencies=[Depends(require_api_key)])
-@limiter.limit("10/minute")
-async def clear_scans(request: Request):
-    principal = get_principal(request)
-    deleted = 0
-
-    try:
-        for fname in os.listdir(_SCANS_DIR):
-            if not fname.endswith(".json"):
-                continue
-
-            path = os.path.join(_SCANS_DIR, fname)
-
-            try:
-                with open(path, "r", encoding="utf-8") as f:
-                    scan = json.load(f)
-            except Exception:
-                continue
-
-            if (scan.get("owner") or ANONYMOUS_PRINCIPAL) != principal:
-                continue
-
-            try:
-                os.remove(path)
-                deleted += 1
-            except Exception:
-                pass
-
-        return {"deleted": deleted}
-
-    except Exception as e:
-        return JSONResponse(
-            {"error": str(e)},
-            status_code=500
-        )
-
-
+    return {"scan_id": scan_id}
 
 
 @app.websocket("/ws/{scan_id}")
 async def websocket_endpoint(websocket: WebSocket, scan_id: str):
-    try:
-        validate_scan_id(scan_id)
-    except Exception:
-        await websocket.close(code=1008)
-        return
-    token = websocket.query_params.get("api_key", "")
-    principal = principal_for_key(token)
-    if principal is None:
-        await websocket.close(code=1008)
-        return
-                                                                              
-    scan = _scans.get(scan_id) or _load_scan(scan_id)
-    if scan and not _scan_visible_to(scan, principal):
-        await websocket.close(code=1008)
-        return
-    await websocket.accept()
-    q = _queues.get(scan_id)
-    if not q:
-        await websocket.send_json({"type": "error", "error": "Unknown scan ID"})
-        await websocket.close()
-        return
-
-    try:
-        while True:
-            msg = await asyncio.wait_for(q.get(), timeout=120)
-            await websocket.send_json(msg)
-            if msg.get("type") == "_done":
-                break
-    except asyncio.TimeoutError:
-        await websocket.send_json({"type": "error", "error": "Scan timed out"})
-    except WebSocketDisconnect:
-        pass
-    finally:
-        _queues.pop(scan_id, None)
-        try:
-            await websocket.close()
-        except Exception:
-            pass
-
-def _frontend_config_script() -> str:
-    config = {
-        "apiUrl": os.getenv("NEXT_PUBLIC_API_URL", ""),
-        "apiKey": os.getenv("PRISM_UI_API_KEY", os.getenv("NEXT_PUBLIC_API_KEY", "")),
-        "basePath": _BASE_PATH,
-        "demoMode": env_flag("PRISM_DEMO_MODE"),
-    }
-    payload = json.dumps(config, separators=(",", ":")).replace("</", "<\\/")
-    return f'<script id="prism-runtime-config">window.__PRISM_CONFIG__={payload};</script>'
-
-def _frontend_not_found() -> JSONResponse:
-    return JSONResponse({"detail": "Frontend build not found"}, status_code=404)
-
-def _is_reserved_frontend_path(path: str) -> bool:
-    first_segment = path.strip("/").split("/", 1)[0]
-    return first_segment in _RESERVED_FRONTEND_PATHS
-
-def _safe_frontend_file(path: str) -> Optional[Path]:
-    if not _FRONTEND_DIR.is_dir():
-        return None
-    root = _FRONTEND_DIR.resolve()
-    try:
-        candidate = (root / path).resolve()
-        candidate.relative_to(root)
-    except ValueError:
-        return None
-    if candidate.is_dir():
-        index = candidate / "index.html"
-        return index if index.is_file() else None
-    return candidate if candidate.is_file() else None
-
-def _serve_frontend_index(index_path: Path) -> Response:
-    html = index_path.read_text(encoding="utf-8")
-    script = _frontend_config_script()
-    if "</head>" in html:
-        html = html.replace("</head>", f"{script}</head>", 1)
+    """WebSocket endpoint for real-time scan updates."""
+    # Check API key via query param
+    api_key = websocket.query_params.get("api_key")
+    if api_key:
+        # Verify the key
+        if not API_KEYS or api_key not in API_KEYS.split(","):
+            await websocket.close(code=1008, reason="Invalid API key")
+            return
+        principal = api_key
     else:
-        html = f"{script}{html}"
-    return Response(html, media_type="text/html")
+        principal = "anonymous"
 
-def _serve_frontend_path(path: str):
-    normalized = path.strip("/")
-    if normalized and _is_reserved_frontend_path(normalized):
-        return JSONResponse({"detail": "Not found"}, status_code=404)
+    # Check if the scan exists and belongs to this principal
+    scan = await scan_state.get(scan_id, principal)
+    if not scan:
+        await websocket.close(code=1000, reason="Scan not found")
+        return
 
-    file_path = _safe_frontend_file(normalized or "index.html")
-    if file_path:
-        if file_path.name == "index.html":
-            return _serve_frontend_index(file_path)
-        return FileResponse(file_path)
+    await manager.connect(scan_id, websocket)
 
-    index_path = _safe_frontend_file("index.html")
-    if index_path:
-        return _serve_frontend_index(index_path)
-    return _frontend_not_found()
+    try:
+        # Send initial state
+        await websocket.send_json({"type": "init", "scan": scan})
 
-@app.get("/", include_in_schema=False)
-async def frontend_root():
-    return _serve_frontend_path("")
+        # Keep the connection alive and forward updates
+        while True:
+            # Ping to keep connection alive
+            await websocket.send_json({"type": "ping"})
+            await asyncio.sleep(30)
 
-@app.get("/{full_path:path}", include_in_schema=False)
-async def frontend_fallback(full_path: str):
-    return _serve_frontend_path(full_path)
+    except WebSocketDisconnect:
+        manager.disconnect(scan_id)
+    except Exception as e:
+        manager.disconnect(scan_id)
+
+
+@app.get("/api/scans")
+async def list_scans(request: Request):
+    """List scans for the authenticated principal."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    limit = request.query_params.get("limit", 20)
+    try:
+        limit = int(limit)
+    except ValueError:
+        limit = 20
+
+    scans = await scan_state.list_scans(principal, limit)
+    return {"scans": scans}
+
+
+@app.get("/api/scan/{scan_id}")
+async def get_scan(request: Request, scan_id: str):
+    """Get scan details."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    scan = await scan_state.get(scan_id, principal)
+    if not scan:
+        raise HTTPException(status_code=404, detail="Scan not found")
+
+    return {"scan": scan}
+
+
+@app.get("/api/scan/{scan_id}/report.{format}")
+async def get_report(request: Request, scan_id: str, format: str):
+    """Get a report for a scan."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    scan = await scan_state.get(scan_id, principal)
+    if not scan:
+        raise HTTPException(status_code=404, detail="Scan not found")
+
+    results = scan.get("results", {})
+    target = scan.get("target", "unknown")
+    scan_type = scan.get("scan_type", "unknown")
+
+    if format == "html":
+        try:
+            html = generate_html_report(target, scan_type, results)
+            return HTMLResponse(content=html, headers={"Content-Type": "text/html"})
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to generate HTML report: {e}")
+
+    elif format == "pdf":
+        try:
+            pdf = generate_pdf_report(target, scan_type, results)
+            return FileResponse(
+                pdf, media_type="application/pdf",
+                filename=f"{target}_report.pdf"
+            )
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to generate PDF report: {e}")
+
+    elif format == "json":
+        return JSONResponse(results)
+
+    elif format == "graphml":
+        try:
+            graph = results.get("graph", {})
+            if not graph:
+                raise HTTPException(status_code=400, detail="No graph data available")
+            graphml = to_graphml(graph)
+            return HTMLResponse(content=graphml, headers={"Content-Type": "application/xml"})
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to generate GraphML: {e}")
+
+    elif format == "gexf":
+        try:
+            graph = results.get("graph", {})
+            if not graph:
+                raise HTTPException(status_code=400, detail="No graph data available")
+            gexf = to_gexf(graph)
+            return HTMLResponse(content=gexf, headers={"Content-Type": "application/xml"})
+        except Exception as e:
+            raise HTTPException(status_code=500, detail=f"Failed to generate GEXF: {e}")
+
+    else:
+        raise HTTPException(status_code=400, detail=f"Unsupported format: {format}")
+
+
+# Watchlist API endpoints
+@app.post("/api/watchlist")
+async def create_watchlist_endpoint(request: Request):
+    """Create a new watchlist."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    body = await request.json()
+    target = body.get("target", "").strip()
+    scan_type = body.get("type") or detect_scan_type(target)
+
+    if not target:
+        raise HTTPException(status_code=400, detail="Target is required")
+
+    if scan_type != "domain":
+        raise HTTPException(status_code=400, detail="Only domain watchlists are supported")
+
+    modules = body.get("modules", [])
+    interval_hours = body.get("interval_hours", 24)
+
+    entry = create_watchlist(principal, target, scan_type, modules, interval_hours)
+    return {"watchlist": entry}
+
+
+@app.get("/api/watchlist")
+async def list_watchlists_endpoint(request: Request):
+    """List watchlists for the authenticated principal."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    entries = list_watchlists(principal)
+    return {"watchlists": entries}
+
+
+@app.get("/api/watchlist/{watchlist_id}")
+async def get_watchlist_endpoint(request: Request, watchlist_id: str):
+    """Get a watchlist entry."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    entry = get_watchlist(watchlist_id)
+    if not entry or entry.get("owner") != principal:
+        raise HTTPException(status_code=404, detail="Watchlist not found")
+
+    # Remove owner from response
+    entry = {k: v for k, v in entry.items() if k != "owner"}
+    return {"watchlist": entry}
+
+
+@app.delete("/api/watchlist/{watchlist_id}")
+async def delete_watchlist_endpoint(request: Request, watchlist_id: str):
+    """Delete a watchlist."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    deleted = delete_watchlist(watchlist_id, principal)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Watchlist not found")
+
+    return {"success": True}
+
+
+@app.patch("/api/watchlist/{watchlist_id}/pause")
+async def pause_watchlist_endpoint(request: Request, watchlist_id: str):
+    """Pause or unpause a watchlist."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    body = await request.json()
+    paused = body.get("paused", True)
+
+    entry = set_paused(watchlist_id, principal, paused)
+    if entry is None:
+        raise HTTPException(status_code=404, detail="Watchlist not found")
+
+    return {"watchlist": entry}
+
+
+@app.get("/api/watchlist/{watchlist_id}/status")
+async def watchlist_status_endpoint(request: Request, watchlist_id: str):
+    """Get the current status of a watchlist."""
+    principal = validate_api_key(request)
+    if principal is None:
+        raise HTTPException(status_code=401, detail="Invalid or missing API key")
+
+    status = get_watchlist_status(watchlist_id, principal)
+    if status is None:
+        raise HTTPException(status_code=404, detail="Watchlist not found")
+
+    return {"status": status}
+
+
+# Frontend route
+@app.get("/")
+async def serve_frontend(request: Request):
+    """Serve the frontend."""
+    # Check if we have frontend files
+    index_path = os.path.join(frontend_dir, "index.html")
+    if os.path.exists(index_path):
+        return FileResponse(index_path)
+
+    # Check if we're in development mode
+    if os.getenv("NEXT_PUBLIC_API_URL"):
+        return HTMLResponse("""
+            <!DOCTYPE html>
+            <html>
+                <head><title>PRISM OSINT</title></head>
+                <body>
+                    <h1>PRISM OSINT</h1>
+                    <p>Frontend not found. Please build the frontend or set PRISM_FRONTEND_DIR.</p>
+                    <p>API is running at <a href="/docs">/docs</a></p>
+                </body>
+            </html>
+        """)
+
+    raise HTTPException(status_code=404, detail="Frontend not found")
+
 
 if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run("web.app:app", host="0.0.0.0", port=8080, reload=True, proxy_headers=False)
+    uvicorn.run(
+        "web.app:app",
+        host="0.0.0.0",
+        port=8080,
+        reload=False,
+        no_proxy_headers=True,
+    )


### PR DESCRIPTION
Add RDAP (Registration Data Access Protocol) module as a modern alternative to WHOIS for domain registration lookups.

Key features:
- Uses IANA bootstrap file for RDAP server discovery per TLD
- Falls back to rdap.org as resolver if bootstrap unavailable
- Returns structured JSON data: registration dates, registrar, nameservers, registrant contacts (vCard parsing)
- Proper status handling: OK for registered/unregistered domains, SKIPPED for TLDs not serving RDAP, ERROR for failures
- Full test coverage with mocked network requests

Integration:
- Added modules/rdap.py with RDAPLookup class
- Added tests/test_rdap.py with comprehensive test cases
- Wired into cli.py scan command
- Wired into web/app.py FastAPI backend
- Added RDAP to frontend Sidebar.tsx module map
- Added RDAP display card to ScanResults.tsx

Closes #302

## Summary
<!-- Describe your changes briefly -->

## Changes
<!-- List specific changes -->
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
