### PR TITLE
Add tooltips to standalone tool cards

### DIFF
--- a/frontend/src/components/views/IdleView.tsx
+++ b/frontend/src/components/views/IdleView.tsx
@@ -164,11 +164,12 @@ export function IdleView({ onTool, onScan, isStarting = false }: Props) {
           {TOOL_IDS.map(toolId => {
             const Icon = ICONS[toolId];
             return (
-              <button
+                <button
                 key={toolId}
                 onClick={() => onTool(toolId as ToolMode)}
+                title={t(`idle.tools.${toolId}.desc`)}
                 className="card px-3 py-2 text-left hover:border-border-3 hover:bg-surface-3 transition-all group flex items-center gap-2.5 cursor-pointer"
-              >
+                >
                 <Icon size={13} className="text-blue shrink-0" />
                 <div className="min-w-0">
                   <div className="text-[11px] font-semibold text-text-1 leading-tight">{t(`idle.tools.${toolId}.label`)}</div>


### PR DESCRIPTION
Adds a title attribute to each tool card button, reusing the existing translation description so hovering shows a short explanation of what the tool does.

Closes #201

## Summary
Adds hover tooltips to the standalone tool cards (File Metadata, Email Headers, Crypto, QR, etc.) on the landing page.

## Changes
- Added a title attribute to the tool card button in frontend/src/components/views/IdleView.tsx, reusing the tool's existing translated description as the hover tooltip text.

## Type of change
- [x] Documentation / UX improvement