### PR TITLE
feat: add RDAP module alongside WHOIS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -71,6 +71,11 @@ async def run_scan(
             from modules.extra_tools import WhoisLookup
             results["whois"] = await _invoke(WhoisLookup().lookup, target)
 
+        if want("rdap") and scan_type == "domain":
+            _log("Running rdap ...")
+            from modules.rdap import RDAPLookup
+            results["rdap"] = await _invoke(RDAPLookup().lookup, target)
+
         if want("dns") and scan_type == "domain":
             _log("Running dns ...")
             from modules.extra_tools import DNSLookup

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -333,6 +333,8 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isStarting =
               </button>
             )}
 
+
+
             <div className="flex items-center gap-1 mb-1.5">
               <button
                 onClick={() => { setCompareMode(v => !v); setCompareSelection([]); }}
@@ -351,10 +353,13 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isStarting =
     <Trash2 size={10} />
   </button>
 
+
               <button onClick={fetchHistory} className="text-text-3 hover:text-text-2 transition-colors ml-auto" aria-label="Refresh history">
                 <RotateCcw size={10} className={historyLoading ? 'spin' : ''} />
               </button>
             </div>
+
+
 
             {historyLoading ? (
               <div className="flex justify-center py-2"><Loader2 size={14} className="spin text-text-3" /></div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -18,7 +18,7 @@ interface RecentScan { target: string; type: ScanType; ts: number; }
 const SCAN_TYPES: ScanType[] = ['domain', 'ip', 'email', 'phone', 'username'];
 
 export const MODULE_MAP: Record<ScanType, string[]> = {
-  domain:   ['whois', 'dns', 'geoip', 'cert_transparency', 'website', 'wayback', 'shodan', 'virustotal', 'censys', 'onion', 'hudsonrock', 'lunar'],
+  domain:   ['whois', 'dns', 'geoip', 'cert_transparency', 'website', 'wayback', 'shodan', 'virustotal', 'censys', 'onion', 'hudsonrock', 'lunar', 'rdap'],
   ip:       ['geoip', 'shodan', 'virustotal', 'abuseipdb', 'censys'],
   email:    ['emailrep', 'smtp', 'leaks', 'gravatar', 'hudsonrock'],
   phone:    ['hlr'],
@@ -47,6 +47,7 @@ const MODULE_DESCRIPTIONS: Record<string, string> = {
   blackbird: 'Search for a username across online platforms with Blackbird',
   maigret: 'Search for a username across websites with Maigret',
   github: 'Search GitHub for information associated with a username',
+  rdap: 'Look up domain registration using RDAP (modern WHOIS replacement)',
 };
 
 interface Props {
@@ -332,9 +333,6 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isStarting =
               </button>
             )}
 
-
-
-
             <div className="flex items-center gap-1 mb-1.5">
               <button
                 onClick={() => { setCompareMode(v => !v); setCompareSelection([]); }}
@@ -342,7 +340,6 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isStarting =
                   compareMode ? 'bg-purple/20 text-purple border border-purple/30' : 'bg-surface-3 text-text-3 border border-border-1 hover:text-text-2'
                 }`}
               >
-                
                 <span className="flex items-center gap-1"><GitCompare size={8} /> {t('sidebar.compare')}</span>
               </button>
 
@@ -354,16 +351,10 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isStarting =
     <Trash2 size={10} />
   </button>
 
-
               <button onClick={fetchHistory} className="text-text-3 hover:text-text-2 transition-colors ml-auto" aria-label="Refresh history">
                 <RotateCcw size={10} className={historyLoading ? 'spin' : ''} />
               </button>
             </div>
-
-
-
-
-
 
             {historyLoading ? (
               <div className="flex justify-center py-2"><Loader2 size={14} className="spin text-text-3" /></div>

--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -433,6 +433,7 @@ const OPSEC_CATEGORY_INFO: Record<string, { label: string; tooltip: string }> = 
 const TABS = [
   { id: 'findings', label: 'Findings', icon: Shield },
   { id: 'whois', label: 'WHOIS', icon: Globe },
+  { id: 'rdap', label: 'RDAP', icon: Globe },
   { id: 'dns', label: 'DNS', icon: Server },
   { id: 'subdomains', label: 'Subdomains', icon: Lock },
   { id: 'accounts', label: 'Accounts', icon: User },
@@ -794,6 +795,7 @@ export function ScanResults({ scan, onHome }: Props) {
 
   const visibleTabs = TABS.filter(t => {
     if (t.id === 'whois') return r.whois && !r.whois.error;
+    if (t.id === 'rdap') return r.rdap && !r.rdap.error;
     if (t.id === 'dns') return r.dns?.records && Object.keys(r.dns.records).length > 0;
     if (t.id === 'subdomains') return r.cert_transparency?.subdomains?.length;
     if (t.id === 'accounts') return accounts.some(b => b.status === 'found');
@@ -992,6 +994,47 @@ export function ScanResults({ scan, onHome }: Props) {
                       </span>
                     ))}
                   </div>
+                </div>
+              )}
+            </div>
+          </Card>
+        )}
+
+        {/* RDAP */}
+        {tab === 'rdap' && r.rdap && !r.rdap.error && (
+          <Card title="RDAP Registration" onRefresh={() => refreshModule('rdap')} refreshing={isRefreshing('rdap')}>
+            <div className="space-y-1.5">
+              {r.rdap.registered === false && (
+                <div className="text-text-3 text-sm py-2">Domain is not registered</div>
+              )}
+              {r.rdap.registrar && (
+                <div className="dt-row"><span className="dt-label">Registrar</span><span className="dt-value">{r.rdap.registrar}</span></div>
+              )}
+              {r.rdap.created && (
+                <div className="dt-row"><span className="dt-label">Created</span><span className="dt-value">{r.rdap.created}</span></div>
+              )}
+              {r.rdap.expires && (
+                <div className="dt-row"><span className="dt-label">Expires</span><span className="dt-value">{r.rdap.expires}</span></div>
+              )}
+              {r.rdap.updated && (
+                <div className="dt-row"><span className="dt-label">Updated</span><span className="dt-value">{r.rdap.updated}</span></div>
+              )}
+              {r.rdap.nameservers && r.rdap.nameservers.length > 0 && (
+                <div className="dt-row"><span className="dt-label">Name Servers</span>
+                  <div className="flex flex-wrap gap-1">
+                    {r.rdap.nameservers.slice(0, 4).map(ns => (
+                      <span key={ns} className="tag">{ns}</span>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {r.rdap.registrant && (
+                <div className="mt-2 p-2 bg-surface-2 rounded">
+                  <div className="text-[10px] text-text-3 uppercase tracking-wider mb-1">Registrant</div>
+                  {r.rdap.registrant.name && <div className="text-sm">{r.rdap.registrant.name}</div>}
+                  {r.rdap.registrant.organization && <div className="text-xs text-text-2">{r.rdap.registrant.organization}</div>}
+                  {r.rdap.registrant.email && <div className="text-xs text-text-2">{r.rdap.registrant.email}</div>}
+                  {r.rdap.registrant.country && <div className="text-xs text-text-2">{r.rdap.registrant.country}</div>}
                 </div>
               )}
             </div>

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -236,12 +236,47 @@ export interface GravatarData extends ModuleStatusFields {
   error?: string;
 }
 
+export interface RDAPData extends ModuleStatusFields {
+  domain?: string;
+  rdap_url?: string;
+  registered?: boolean | null;
+  created?: string | null;
+  expires?: string | null;
+  updated?: string | null;
+  registrar?: string | null;
+  registrant?: {
+    name?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    organization?: string | null;
+    country?: string | null;
+  } | null;
+  administrative?: {
+    name?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    organization?: string | null;
+    country?: string | null;
+  } | null;
+  technical?: {
+    name?: string | null;
+    email?: string | null;
+    phone?: string | null;
+    organization?: string | null;
+    country?: string | null;
+  } | null;
+  nameservers?: string[];
+  raw?: unknown;
+  error?: string | null;
+}
+
 export interface BlackbirdFailure extends ModuleStatusFields {
   error?: string;
 }
 
 export interface ScanResults {
   whois?: WhoisData;
+  rdap?: RDAPData;
   dns?: DnsRecord;
   geoip?: GeoipData;
   cert_transparency?: CertTransparencyData;

--- a/modules/rdap.py
+++ b/modules/rdap.py
@@ -70,7 +70,7 @@ class RDAPLookup:
             "organization": None,
             "country": None,
         }
-        contact["name"] = entity.get("handle") or entity.get("fn")
+        contact["name"] = entity.get("fn") or entity.get("handle")
         vcard = entity.get("vcardArray", [])
         if len(vcard) > 1 and isinstance(vcard[1], list):
             for prop in vcard[1]:
@@ -98,7 +98,7 @@ class RDAPLookup:
         result: Dict[str, Any] = {
             "domain": domain,
             "rdap_url": None,
-            "status": None,
+            "registered": None,
             "created": None,
             "expires": None,
             "updated": None,
@@ -125,7 +125,7 @@ class RDAPLookup:
                 headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
             )
             if r.status_code == 404:
-                result["status"] = "unregistered"
+                result["registered"] = False
                 return annotate(result, OK, "Domain is not registered")
             if r.status_code == 403:
                 return annotate(result, SKIPPED, "RDAP server refused the request (access denied)")
@@ -155,7 +155,7 @@ class RDAPLookup:
                     return annotate(result, SKIPPED, f"RDAP unavailable (HTTP {r.status_code})")
 
             data = r.json()
-            result["status"] = "registered"
+            result["registered"] = True
 
             events = data.get("events", [])
             if isinstance(events, list):
@@ -179,7 +179,7 @@ class RDAPLookup:
                 if not isinstance(roles, list):
                     roles = [roles] if roles else []
                 if "registrar" in roles or "registrar" in entity.get("type", "").lower():
-                    result["registrar"] = entity.get("handle") or entity.get("fn")
+                    result["registrar"] = entity.get("fn") or entity.get("handle")
                 if "registrant" in roles:
                     result["registrant"] = self._parse_contact(entity)
                 if "administrative" in roles or "admin" in roles:

--- a/modules/rdap.py
+++ b/modules/rdap.py
@@ -1,0 +1,213 @@
+import ipaddress
+import re
+from typing import Any, Dict, List, Optional
+
+import requests
+
+from modules.module_status import annotate, OK, SKIPPED, ERROR
+
+IANA_BOOTSTRAP_URL = "https://data.iana.org/rdap/dns.json"
+
+
+class RDAPLookup:
+    def __init__(self, timeout: int = 15, use_bootstrap: bool = True):
+        self.timeout = timeout
+        self.use_bootstrap = use_bootstrap
+        self._bootstrap_cache: Optional[Dict[str, str]] = None
+
+    def _load_bootstrap(self) -> Dict[str, str]:
+        if self._bootstrap_cache is not None:
+            return self._bootstrap_cache
+        try:
+            r = requests.get(IANA_BOOTSTRAP_URL, timeout=self.timeout)
+            if r.status_code != 200:
+                return {}
+            data = r.json()
+            services = data.get("services", [])
+            tld_map: Dict[str, str] = {}
+            for service in services:
+                if not isinstance(service, list) or len(service) < 2:
+                    continue
+                tlds = service[0] if isinstance(service[0], list) else []
+                urls = service[1] if isinstance(service[1], list) else []
+                if not tlds or not urls:
+                    continue
+                rdap_url = urls[0]
+                for tld in tlds:
+                    if isinstance(tld, str):
+                        tld_map[tld.lower()] = rdap_url
+            self._bootstrap_cache = tld_map
+            return tld_map
+        except Exception:
+            return {}
+
+    def _get_rdap_url(self, domain: str) -> str:
+        domain_lower = domain.lower().strip()
+        domain = domain_lower.rstrip(".")
+        parts = domain.split(".")
+        tld = parts[-1].lower() if parts else ""
+        if self.use_bootstrap:
+            tld_map = self._load_bootstrap()
+            if tld in tld_map:
+                base_url = tld_map[tld]
+                if not base_url.endswith("/"):
+                    base_url += "/"
+                return f"{base_url}domain/{domain}"
+        return f"https://rdap.org/domain/{domain}"
+
+    def _format_date(self, date_str: Optional[str]) -> Optional[str]:
+        if not date_str:
+            return None
+        if re.match(r"^\d{4}-\d{2}-\d{2}", date_str):
+            return date_str
+        return date_str
+
+    def _parse_contact(self, entity: Dict[str, Any]) -> Dict[str, Optional[str]]:
+        contact = {
+            "name": None,
+            "email": None,
+            "phone": None,
+            "organization": None,
+            "country": None,
+        }
+        contact["name"] = entity.get("handle") or entity.get("fn")
+        vcard = entity.get("vcardArray", [])
+        if len(vcard) > 1 and isinstance(vcard[1], list):
+            for prop in vcard[1]:
+                if not isinstance(prop, list) or len(prop) < 3:
+                    continue
+                prop_name = prop[0]
+                prop_value = prop[2] if len(prop) > 2 else None
+                if prop_name == "fn":
+                    contact["name"] = prop_value
+                elif prop_name == "email":
+                    contact["email"] = prop_value
+                elif prop_name == "tel":
+                    contact["phone"] = prop_value
+                elif prop_name == "org":
+                    contact["organization"] = prop_value
+                elif prop_name == "adr" and isinstance(prop_value, list) and len(prop_value) > 6:
+                    contact["country"] = prop_value[6]
+        if not contact["organization"]:
+            contact["organization"] = entity.get("org")
+        return contact
+
+    def lookup(self, domain: str) -> Dict[str, Any]:
+        domain = (domain or "").strip().lower()
+        domain = domain.rstrip(".")
+        result: Dict[str, Any] = {
+            "domain": domain,
+            "rdap_url": None,
+            "status": None,
+            "created": None,
+            "expires": None,
+            "updated": None,
+            "registrar": None,
+            "registrant": None,
+            "administrative": None,
+            "technical": None,
+            "nameservers": [],
+            "raw": None,
+            "error": None,
+        }
+        if not domain:
+            return annotate(result, ERROR, "No domain provided")
+        if not re.match(r"^[a-z0-9][a-z0-9.-]*\.[a-z]{2,}$", domain):
+            return annotate(result, ERROR, f"Invalid domain format: {domain}")
+
+        rdap_url = self._get_rdap_url(domain)
+        result["rdap_url"] = rdap_url
+
+        try:
+            r = requests.get(
+                rdap_url,
+                timeout=self.timeout,
+                headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
+            )
+            if r.status_code == 404:
+                result["status"] = "unregistered"
+                return annotate(result, OK, "Domain is not registered")
+            if r.status_code == 403:
+                return annotate(result, SKIPPED, "RDAP server refused the request (access denied)")
+            if r.status_code == 429:
+                return annotate(result, SKIPPED, "RDAP server rate limited the request")
+
+            if r.status_code != 200:
+                if r.status_code in (301, 302, 303, 307, 308):
+                    location = r.headers.get("location")
+                    if location:
+                        result["rdap_url"] = location
+                        try:
+                            r2 = requests.get(
+                                location,
+                                timeout=self.timeout,
+                                headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
+                            )
+                            if r2.status_code == 200:
+                                r = r2
+                            else:
+                                return annotate(result, SKIPPED, f"RDAP unavailable for this TLD (HTTP {r.status_code})")
+                        except Exception:
+                            return annotate(result, SKIPPED, "RDAP unavailable for this TLD")
+                    else:
+                        return annotate(result, SKIPPED, f"RDAP unavailable for this TLD (HTTP {r.status_code})")
+                else:
+                    return annotate(result, SKIPPED, f"RDAP unavailable (HTTP {r.status_code})")
+
+            data = r.json()
+            result["status"] = "registered"
+            result["created"] = self._format_date(data.get("events", {}).get("registration") or data.get("registrationDate"))
+            result["expires"] = self._format_date(data.get("events", {}).get("expiration") or data.get("expirationDate"))
+
+            events = data.get("events", [])
+            if isinstance(events, list):
+                for event in events:
+                    if not isinstance(event, dict):
+                        continue
+                    action = event.get("eventAction") or event.get("action")
+                    date = event.get("eventDate") or event.get("date")
+                    if action == "registration":
+                        result["created"] = self._format_date(date)
+                    elif action == "expiration":
+                        result["expires"] = self._format_date(date)
+                    elif action == "last changed" or action == "lastChanged":
+                        result["updated"] = self._format_date(date)
+
+            entities = data.get("entities", [])
+            for entity in entities:
+                if not isinstance(entity, dict):
+                    continue
+                roles = entity.get("roles") or entity.get("role") or []
+                if not isinstance(roles, list):
+                    roles = [roles] if roles else []
+                if "registrar" in roles or "registrar" in entity.get("type", "").lower():
+                    result["registrar"] = entity.get("handle") or entity.get("fn")
+                if "registrant" in roles:
+                    result["registrant"] = self._parse_contact(entity)
+                if "administrative" in roles or "admin" in roles:
+                    result["administrative"] = self._parse_contact(entity)
+                if "technical" in roles:
+                    result["technical"] = self._parse_contact(entity)
+
+            nameservers = data.get("nameservers", [])
+            if isinstance(nameservers, list):
+                for ns in nameservers:
+                    if isinstance(ns, dict):
+                        ns_name = ns.get("ldhName") or ns.get("fqdn") or ns.get("name")
+                        if ns_name:
+                            result["nameservers"].append(ns_name)
+
+            result["raw"] = data
+            return annotate(result, OK)
+
+        except requests.Timeout:
+            return annotate(result, SKIPPED, "RDAP request timed out")
+        except requests.ConnectionError:
+            return annotate(result, SKIPPED, "RDAP connection error")
+        except Exception as e:
+            return annotate(result, ERROR, str(e)[:200])
+
+
+def run_rdap_lookup(domain: str) -> Dict[str, Any]:
+    rdap = RDAPLookup()
+    return rdap.lookup(domain)

--- a/modules/rdap.py
+++ b/modules/rdap.py
@@ -156,8 +156,6 @@ class RDAPLookup:
 
             data = r.json()
             result["status"] = "registered"
-            result["created"] = self._format_date(data.get("events", {}).get("registration") or data.get("registrationDate"))
-            result["expires"] = self._format_date(data.get("events", {}).get("expiration") or data.get("expirationDate"))
 
             events = data.get("events", [])
             if isinstance(events, list):

--- a/tests/test_rdap.py
+++ b/tests/test_rdap.py
@@ -1,0 +1,204 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from modules.rdap import RDAPLookup
+from modules.module_status import classify, OK, SKIPPED, ERROR
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, data=None, headers=None):
+        self.status_code = status_code
+        self._data = data or {}
+        self.headers = headers or {}
+
+    def json(self):
+        return self._data
+
+
+REGISTERED_RESPONSE = {
+    "handle": "123456789_DOMAIN_COM-VRSN",
+    "ldhName": "example.com",
+    "registrationDate": "1995-08-14T04:00:00Z",
+    "expirationDate": "2025-08-13T04:00:00Z",
+    "events": [
+        {"eventAction": "registration", "eventDate": "1995-08-14T04:00:00Z"},
+        {"eventAction": "expiration", "eventDate": "2025-08-13T04:00:00Z"},
+        {"eventAction": "last changed", "eventDate": "2023-05-01T12:00:00Z"},
+    ],
+    "entities": [
+        {
+            "handle": "REG-123",
+            "fn": "Example Registrar",
+            "roles": ["registrar"],
+        },
+        {
+            "handle": "R-001",
+            "fn": "Domain Owner",
+            "roles": ["registrant"],
+            "vcardArray": [
+                "vcard",
+                [
+                    ["fn", {}, "Domain Owner"],
+                    ["org", {}, "Example Corp"],
+                    ["email", {}, "admin@example.com"],
+                    ["tel", {}, "+1-555-123-4567"],
+                    ["adr", {}, ["", "", "123 Main St", "Anytown", "CA", "90210", "US"]],
+                ],
+            ],
+        },
+    ],
+    "nameservers": [
+        {"ldhName": "ns1.example.com"},
+        {"ldhName": "ns2.example.com"},
+    ],
+}
+
+
+def test_rdap_lookup_registered_domain(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse(200, REGISTERED_RESPONSE)
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+        assert classify(result) == OK
+        assert result["domain"] == "example.com"
+        assert result["status"] == "registered"
+        assert result["created"] == "1995-08-14T04:00:00Z"
+        assert result["expires"] == "2025-08-13T04:00:00Z"
+        assert result["updated"] == "2023-05-01T12:00:00Z"
+        assert result["registrar"] == "Example Registrar"
+        assert "ns1.example.com" in result["nameservers"]
+        assert "ns2.example.com" in result["nameservers"]
+        assert result["registrant"] is not None
+        assert result["registrant"].get("name") == "Domain Owner"
+        assert result["registrant"].get("email") == "admin@example.com"
+        assert result["error"] is None
+
+
+def test_rdap_lookup_unregistered_domain(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse(404, {})
+        rdap = RDAPLookup()
+        result = rdap.lookup("notarealdomain123456789.com")
+        assert classify(result) == OK
+        assert result["status"] == "unregistered"
+        assert result["error"] is None
+
+
+def test_rdap_lookup_empty_domain():
+    rdap = RDAPLookup()
+    result = rdap.lookup("")
+    assert classify(result) == ERROR
+    assert "No domain provided" in result["error"]
+
+
+def test_rdap_lookup_invalid_domain():
+    rdap = RDAPLookup()
+    result = rdap.lookup("invalid@@domain")
+    assert classify(result) == ERROR
+    assert "Invalid domain format" in result["error"]
+
+
+def test_rdap_lookup_tld_not_served(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse(501, {})
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.xx")
+        assert classify(result) == SKIPPED
+        assert "RDAP unavailable" in result["status_reason"]
+        assert result["error"] is None
+
+
+def test_rdap_lookup_rate_limited(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.return_value = FakeResponse(429, {})
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+        assert classify(result) == SKIPPED
+        assert "rate limited" in result["status_reason"]
+        assert result["error"] is None
+
+
+def test_rdap_lookup_timeout(monkeypatch):
+    import requests
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.side_effect = requests.exceptions.Timeout()
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+        assert classify(result) == SKIPPED
+        assert "timed out" in result["status_reason"]
+        assert result["error"] is None
+
+
+def test_rdap_lookup_connection_error(monkeypatch):
+    import requests
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.side_effect = requests.exceptions.ConnectionError()
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+        assert classify(result) == SKIPPED
+        assert "connection" in result["status_reason"]
+        assert result["error"] is None
+
+
+def test_rdap_bootstrap_loading(monkeypatch):
+    bootstrap_data = {
+        "services": [
+            [
+                ["com", "net", "org"],
+                ["https://rdap.verisign.com/com/v1/", "https://rdap.verisign.com/net/v1/"],
+            ],
+            [["de"], ["https://rdap.denic.de/"]],
+        ]
+    }
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.side_effect = [
+            FakeResponse(200, bootstrap_data),
+            FakeResponse(200, REGISTERED_RESPONSE),
+        ]
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+        assert mock_get.call_count == 2
+        first_call = mock_get.call_args_list[0]
+        assert first_call[0][0] == "https://data.iana.org/rdap/dns.json"
+        second_call = mock_get.call_args_list[1]
+        assert "rdap.verisign.com" in second_call[0][0]
+        assert "example.com" in second_call[0][0]
+        assert classify(result) == OK
+
+
+def test_rdap_bootstrap_fallback(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        mock_get.side_effect = [
+            FakeResponse(404, {}),
+            FakeResponse(200, REGISTERED_RESPONSE),
+        ]
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+        assert mock_get.call_count == 2
+        second_call = mock_get.call_args_list[1]
+        assert "rdap.org" in second_call[0][0]
+        assert classify(result) == OK
+
+
+def test_rdap_lookup_redirect_following(monkeypatch):
+    with patch("modules.rdap.requests.get") as mock_get:
+        redirect_response = FakeResponse(
+            302,
+            {},
+            {"location": "https://rdap.verisign.com/com/v1/domain/example.com"},
+        )
+        mock_get.side_effect = [
+            redirect_response,
+            FakeResponse(200, REGISTERED_RESPONSE),
+        ]
+        rdap = RDAPLookup()
+        result = rdap.lookup("example.com")
+        assert mock_get.call_count == 2
+        second_call = mock_get.call_args_list[1]
+        assert "rdap.verisign.com" in second_call[0][0]
+        assert classify(result) == OK

--- a/tests/test_rdap.py
+++ b/tests/test_rdap.py
@@ -32,8 +32,8 @@ REGISTERED_RESPONSE = {
     ],
     "entities": [
         {
-            "handle": "REG-123",
-            "fn": "Example Registrar",
+            "handle": "292",
+            "fn": "MarkMonitor Inc.",
             "roles": ["registrar"],
         },
         {
@@ -66,11 +66,11 @@ def test_rdap_lookup_registered_domain(monkeypatch):
         result = rdap.lookup("example.com")
         assert classify(result) == OK
         assert result["domain"] == "example.com"
-        assert result["status"] == "registered"
+        assert result["registered"] is True
         assert result["created"] == "1995-08-14T04:00:00Z"
         assert result["expires"] == "2025-08-13T04:00:00Z"
         assert result["updated"] == "2023-05-01T12:00:00Z"
-        assert result["registrar"] == "Example Registrar"
+        assert result["registrar"] == "MarkMonitor Inc."
         assert "ns1.example.com" in result["nameservers"]
         assert "ns2.example.com" in result["nameservers"]
         assert result["registrant"] is not None
@@ -85,7 +85,7 @@ def test_rdap_lookup_unregistered_domain(monkeypatch):
         rdap = RDAPLookup()
         result = rdap.lookup("notarealdomain123456789.com")
         assert classify(result) == OK
-        assert result["status"] == "unregistered"
+        assert result["registered"] is False
         assert result["error"] is None
 
 

--- a/web/app.py
+++ b/web/app.py
@@ -29,7 +29,6 @@ from modules.module_status import classify, reason_for, OK, ERROR
 from modules.opsec_score import score_from_results
 from modules.report_generator import generate_html_report, generate_pdf_report
 from modules.webhook_formatters import format_slack, format_discord
-from modules.rdap import RDAPLookup
 
 GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
@@ -458,6 +457,7 @@ async def _run_module(scan_id: str, name: str, coro_or_func, *args, **kwargs) ->
     force_refresh = bool(_scans.get(scan_id, {}).get("force_refresh"))
     if not force_refresh and name in _CACHED_MODULES and cache_target:
         cached = _get_cached(name, str(cache_target))
+        # Ignore legacy non-OK cache entries so the module can re-run.
         if cached is not None and classify(cached) == OK:
             await _push(scan_id, _done_message(name, cached, cached=True))
             return cached
@@ -470,6 +470,7 @@ async def _run_module(scan_id: str, name: str, coro_or_func, *args, **kwargs) ->
         status = classify(result)
         if isinstance(result, dict) and "status" not in result:
             result["status"] = status
+        # Cache only successful results so a missing key is not frozen in cache.
         if name in _CACHED_MODULES and cache_target and status == OK:
             _set_cache(name, str(cache_target), result)
         await _push(scan_id, _done_message(name, result))
@@ -492,6 +493,7 @@ async def _execute_scan(scan_id: str, target: str, scan_type: str, modules: list
                 results["whois"] = await _run_module(scan_id, "whois", WhoisLookup().lookup, target)
 
             if want("rdap") and scan_type == "domain":
+                from modules.rdap import RDAPLookup
                 results["rdap"] = await _run_module(scan_id, "rdap", RDAPLookup().lookup, target)
 
             if want("dns") and scan_type == "domain":

--- a/web/app.py
+++ b/web/app.py
@@ -29,6 +29,7 @@ from modules.module_status import classify, reason_for, OK, ERROR
 from modules.opsec_score import score_from_results
 from modules.report_generator import generate_html_report, generate_pdf_report
 from modules.webhook_formatters import format_slack, format_discord
+from modules.rdap import RDAPLookup
 
 GROQ_API_KEY = os.getenv("GROQ_API_KEY", "")
 OPENROUTER_API_KEY = os.getenv("OPENROUTER_API_KEY", "")
@@ -323,11 +324,8 @@ def _validate_webhook_url(url: str) -> str:
         raise ValueError("webhook_url must be http(s) with a hostname")
     _resolve_all_public(parsed.hostname)
     try:
-                                                                            
-                                                              
         _requests.head(url, timeout=3, allow_redirects=False)
     except Exception:
-                                                                       
         pass
     return url
 
@@ -460,7 +458,6 @@ async def _run_module(scan_id: str, name: str, coro_or_func, *args, **kwargs) ->
     force_refresh = bool(_scans.get(scan_id, {}).get("force_refresh"))
     if not force_refresh and name in _CACHED_MODULES and cache_target:
         cached = _get_cached(name, str(cache_target))
-        # Ignore legacy non-OK cache entries so the module can re-run.
         if cached is not None and classify(cached) == OK:
             await _push(scan_id, _done_message(name, cached, cached=True))
             return cached
@@ -473,7 +470,6 @@ async def _run_module(scan_id: str, name: str, coro_or_func, *args, **kwargs) ->
         status = classify(result)
         if isinstance(result, dict) and "status" not in result:
             result["status"] = status
-        # Cache only successful results so a missing key is not frozen in cache.
         if name in _CACHED_MODULES and cache_target and status == OK:
             _set_cache(name, str(cache_target), result)
         await _push(scan_id, _done_message(name, result))
@@ -494,6 +490,9 @@ async def _execute_scan(scan_id: str, target: str, scan_type: str, modules: list
             if want("whois") and scan_type == "domain":
                 from modules.extra_tools import WhoisLookup
                 results["whois"] = await _run_module(scan_id, "whois", WhoisLookup().lookup, target)
+
+            if want("rdap") and scan_type == "domain":
+                results["rdap"] = await _run_module(scan_id, "rdap", RDAPLookup().lookup, target)
 
             if want("dns") and scan_type == "domain":
                 from modules.extra_tools import DNSLookup
@@ -516,10 +515,6 @@ async def _execute_scan(scan_id: str, target: str, scan_type: str, modules: list
                 )
 
             if want("wayback") and scan_type == "domain":
-                                                                            
-                                                                              
-                                                                            
-                                                            
                 from modules.wayback import WaybackMachine
                 wb = WaybackMachine()
                 wayback_snap = await _run_module(
@@ -533,8 +528,6 @@ async def _execute_scan(scan_id: str, target: str, scan_type: str, modules: list
                     merged["urls"] = wayback_urls.get("urls", [])
                     merged["total_urls"] = wayback_urls.get("total", 0)
                     merged["interesting"] = wayback_urls.get("interesting", [])
-                                                                          
-                                                                           
                     if wayback_urls.get("error") and not merged.get("error"):
                         merged["urls_error"] = wayback_urls["error"]
                 results["wayback"] = merged
@@ -1353,7 +1346,6 @@ async def ai_chat(request: Request, req: dict):
         return JSONResponse({"error": "No message provided"}, status_code=400)
     scan = _load_scan(scan_id) if scan_id else None
     if scan and not _scan_visible_to(scan, get_principal(request)):
-                                                                             
         scan = None
     context = ""
     if scan and scan.get("results"):
@@ -1449,7 +1441,6 @@ async def websocket_endpoint(websocket: WebSocket, scan_id: str):
     if principal is None:
         await websocket.close(code=1008)
         return
-                                                                              
     scan = _scans.get(scan_id) or _load_scan(scan_id)
     if scan and not _scan_visible_to(scan, principal):
         await websocket.close(code=1008)


### PR DESCRIPTION
Add RDAP (Registration Data Access Protocol) module as a modern alternative to WHOIS for domain registration lookups.

Key features:
- Uses IANA bootstrap file for RDAP server discovery per TLD
- Falls back to rdap.org as resolver if bootstrap unavailable
- Returns structured JSON data: registration dates, registrar, nameservers, registrant contacts (vCard parsing)
- Proper status handling: OK for registered/unregistered domains, SKIPPED for TLDs not serving RDAP, ERROR for failures
- Full test coverage with mocked network requests

Integration:
- Added modules/rdap.py with RDAPLookup class
- Added tests/test_rdap.py with comprehensive test cases
- Wired into cli.py scan command
- Wired into web/app.py FastAPI backend
- Added RDAP to frontend Sidebar.tsx module map

Closes #302

## Summary
<!-- Describe your changes briefly -->

## Changes
<!-- List specific changes -->
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
