### PR TITLE
Add / keyboard shortcut hint to target input

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -219,6 +219,7 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isStarting =
               </kbd>
             )}
           </div>
+        </div>
 
         <div>
           <label className="text-[10px] font-semibold text-text-3 uppercase tracking-wider block mb-1.5">{t('sidebar.scanType')}</label>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -213,8 +213,12 @@ export function Sidebar({ onScan, onLoadScan, onCompare, isRunning, isStarting =
                 <X size={12} />
               </button>
             )}
+            {!target && (
+              <kbd className="absolute right-2 top-1/2 -translate-y-1/2 text-[9px] text-text-3 border border-border-1 rounded px-1.5 py-0.5 font-mono hidden sm:block select-none pointer-events-none">
+                /
+              </kbd>
+            )}
           </div>
-        </div>
 
         <div>
           <label className="text-[10px] font-semibold text-text-3 uppercase tracking-wider block mb-1.5">{t('sidebar.scanType')}</label>


### PR DESCRIPTION
Adds a small <kbd>/</kbd> badge inside the target input field to make the keyboard shortcut discoverable. Hidden on small screens for better spacing.

Closes #234

## Summary
<!-- Describe your changes briefly -->

## Changes
<!-- List specific changes -->
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
