### PR TITLE
feat: add "Copy all findings" button to OPSEC findings list

### DIFF
--- a/frontend/src/components/views/ScanResults.tsx
+++ b/frontend/src/components/views/ScanResults.tsx
@@ -959,7 +959,24 @@ export function ScanResults({ scan, onHome }: Props) {
         {tab === 'findings' && (
           <div>
             {opsec?.all_findings?.length ? (
-              <Card title="Security Findings">
+              <Card 
+                title="Security Findings"
+                extra={
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const messages = opsec.all_findings.map(f => f.message).join('\n');
+                      copyValue(messages);
+                    }}
+                    className="text-[10px] font-medium text-text-3 hover:text-text-1 transition-colors px-2 py-0.5 rounded hover:bg-surface-2 flex items-center gap-1"
+                    title="Copy all findings"
+                    aria-label="Copy all findings"
+                  >
+                    <Copy size={11} />
+                    Copy all
+                  </button>
+                }
+              >
                 {opsec.all_findings.map((f, i) => <FindingRow key={i} f={f} />)}
               </Card>
             ) : (


### PR DESCRIPTION
Adds a small "Copy all" button next to the Security Findings heading that copies every finding message (one per line) using the existing copyValue helper and toast notification.

Closes #236

## Summary
<!-- Describe your changes briefly -->

## Changes
<!-- List specific changes -->
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
