### PR TITLE
fix: Make MODULE_PROXY work for all HTTP modules (#324)

### DIFF
--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -1,1 +1,10 @@
 
+import os
+from typing import Dict, Optional
+
+def get_proxies() -> Optional[Dict[str, str]]:
+    """Return a proxies dict for requests if MODULE_PROXY is set."""
+    proxy = os.getenv("MODULE_PROXY", "").strip()
+    if proxy:
+        return {"http": proxy, "https": proxy}
+    return None

--- a/modules/censys_lookup.py
+++ b/modules/censys_lookup.py
@@ -6,6 +6,7 @@ from typing import Any, Dict
 import requests
 
 from modules.module_status import annotate, OK, SKIPPED, RATE_LIMITED, ERROR
+from modules import get_proxies
 
 CENSYS_PAT = os.getenv("CENSYS_PAT", "") or os.getenv("CENSYS_API_KEY", "")
 CENSYS_ORG_ID = os.getenv("CENSYS_ORG_ID", "")
@@ -40,11 +41,13 @@ class CensysLookup:
         if not self.pat:
             return self._err_no_key()
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{CENSYS_BASE}/global/asset/host/{ip}",
                 headers=self._headers(),
                 params=self._params(),
                 timeout=self.timeout,
+                proxies=proxies,  # Add this line
             )
             if r.status_code in (401, 403):
                 return annotate({"results": [], "total": 0}, ERROR, "Invalid Censys token or organization ID")

--- a/modules/censys_lookup.py
+++ b/modules/censys_lookup.py
@@ -47,7 +47,7 @@ class CensysLookup:
                 headers=self._headers(),
                 params=self._params(),
                 timeout=self.timeout,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code in (401, 403):
                 return annotate({"results": [], "total": 0}, ERROR, "Invalid Censys token or organization ID")

--- a/modules/cert_transparency.py
+++ b/modules/cert_transparency.py
@@ -3,6 +3,7 @@ from typing import Dict, Any, List
 import sys
 sys.path.append('..')
 from config import Colors
+from modules import get_proxies
 
 
 class CertTransparency:
@@ -19,13 +20,15 @@ class CertTransparency:
         }
 
         try:
-            params = {"q": f"%.{domain}", "output": "json", "deduplicate": "Y"}
+            proxies = get_proxies()
             response = requests.get(
                 self.BASE_URL,
-                params=params,
+                params = {"q": f"%.{domain}", "output": "json", "deduplicate": "Y"},
                 timeout=30,
                 headers={"User-Agent": "OSINT-Toolkit/2.0"},
+                proxies=proxies,  # Add this line
             )
+
 
             if response.status_code != 200:
                 result["error"] = f"crt.sh returned status {response.status_code}"

--- a/modules/cert_transparency.py
+++ b/modules/cert_transparency.py
@@ -26,7 +26,7 @@ class CertTransparency:
                 params = {"q": f"%.{domain}", "output": "json", "deduplicate": "Y"},
                 timeout=30,
                 headers={"User-Agent": "OSINT-Toolkit/2.0"},
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
 

--- a/modules/crypto_lookup.py
+++ b/modules/crypto_lookup.py
@@ -1,6 +1,7 @@
 import re
 import requests
 from typing import Dict, Any
+from modules import get_proxies
 
 
 class CryptoLookup:
@@ -19,9 +20,11 @@ class CryptoLookup:
 
     def _btc_price(self) -> float:
         try:
+            proxies = get_proxies()
             r = requests.get(
                 "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
                 timeout=6,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 return r.json().get("bitcoin", {}).get("usd", 0)
@@ -31,9 +34,11 @@ class CryptoLookup:
 
     def _eth_price(self) -> float:
         try:
+            proxies = get_proxies()
             r = requests.get(
                 "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd",
                 timeout=6,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 return r.json().get("ethereum", {}).get("usd", 0)
@@ -43,9 +48,11 @@ class CryptoLookup:
 
     def _ltc_price(self) -> float:
         try:
+            proxies = get_proxies()
             r = requests.get(
                 "https://api.coingecko.com/api/v3/simple/price?ids=litecoin&vs_currencies=usd",
                 timeout=6,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 return r.json().get("litecoin", {}).get("usd", 0)
@@ -66,9 +73,11 @@ class CryptoLookup:
             "error": None,
         }
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"https://blockchain.info/rawaddr/{address}?limit=0",
                 timeout=12,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 data = r.json()
@@ -100,9 +109,11 @@ class CryptoLookup:
             "error": None,
         }
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"https://api.ethplorer.io/getAddressInfo/{address}?apiKey=freekey",
                 timeout=12,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 data = r.json()
@@ -132,9 +143,11 @@ class CryptoLookup:
             "error": None,
         }
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"https://api.blockcypher.com/v1/ltc/main/addrs/{address}/balance",
                 timeout=12,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 data = r.json()

--- a/modules/crypto_lookup.py
+++ b/modules/crypto_lookup.py
@@ -24,7 +24,7 @@ class CryptoLookup:
             r = requests.get(
                 "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin&vs_currencies=usd",
                 timeout=6,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 return r.json().get("bitcoin", {}).get("usd", 0)
@@ -38,7 +38,7 @@ class CryptoLookup:
             r = requests.get(
                 "https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd",
                 timeout=6,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 return r.json().get("ethereum", {}).get("usd", 0)
@@ -52,7 +52,7 @@ class CryptoLookup:
             r = requests.get(
                 "https://api.coingecko.com/api/v3/simple/price?ids=litecoin&vs_currencies=usd",
                 timeout=6,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 return r.json().get("litecoin", {}).get("usd", 0)
@@ -77,7 +77,7 @@ class CryptoLookup:
             r = requests.get(
                 f"https://blockchain.info/rawaddr/{address}?limit=0",
                 timeout=12,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 data = r.json()
@@ -113,7 +113,7 @@ class CryptoLookup:
             r = requests.get(
                 f"https://api.ethplorer.io/getAddressInfo/{address}?apiKey=freekey",
                 timeout=12,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 data = r.json()
@@ -147,7 +147,7 @@ class CryptoLookup:
             r = requests.get(
                 f"https://api.blockcypher.com/v1/ltc/main/addrs/{address}/balance",
                 timeout=12,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 data = r.json()

--- a/modules/darkweb_search.py
+++ b/modules/darkweb_search.py
@@ -39,7 +39,7 @@ class DarkWebSearch:
                     params=backend["params"](query),
                     headers=headers,
                     timeout=15,
-                    proxies=proxies,  # Add this line
+                    proxies=proxies,  
                 )
                 if r.status_code == 429:
                     last_error = f'{backend["name"]}: rate limited'

--- a/modules/darkweb_search.py
+++ b/modules/darkweb_search.py
@@ -1,5 +1,6 @@
 import requests
 from typing import Dict, Any, List
+from modules import get_proxies
 
 
 class DarkWebSearch:
@@ -32,11 +33,13 @@ class DarkWebSearch:
 
         for backend in self.BACKENDS:
             try:
+                proxies = get_proxies()
                 r = requests.get(
                     backend["url"],
                     params=backend["params"](query),
                     headers=headers,
                     timeout=15,
+                    proxies=proxies,  # Add this line
                 )
                 if r.status_code == 429:
                     last_error = f'{backend["name"]}: rate limited'

--- a/modules/email_header_analyzer.py
+++ b/modules/email_header_analyzer.py
@@ -3,6 +3,7 @@ import socket
 from email import message_from_string
 from typing import Dict, Any, List, Optional
 import requests
+from modules import get_proxies
 
 
 def _reverse_dns(ip: str) -> Optional[str]:
@@ -31,7 +32,12 @@ def _parse_received_ip(line: str) -> Optional[str]:
 
 def _geoip(ip: str) -> Dict:
     try:
-        r = requests.get(f'https://ipinfo.io/{ip}/json', timeout=6)
+        proxies = get_proxies()  
+        r = requests.get(
+            f'https://ipinfo.io/{ip}/json',
+            timeout=6,
+            proxies=proxies,  
+        )
         if r.status_code == 200:
             d = r.json()
             return {

--- a/modules/extra_tools.py
+++ b/modules/extra_tools.py
@@ -174,7 +174,7 @@ class GeoIPLookup:
                 url,
                 params=params,
                 timeout=10,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if response.status_code == 200:
@@ -332,7 +332,7 @@ class WebsiteAnalyzer:
                 headers=headers,
                 timeout=15,
                 allow_redirects=True,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             html = response.text
 

--- a/modules/extra_tools.py
+++ b/modules/extra_tools.py
@@ -6,6 +6,7 @@ from datetime import datetime
 import sys
 sys.path.append('..')
 from config import IPINFO_API_KEY, Colors
+from modules import get_proxies
 
 try:
     import whois
@@ -168,7 +169,13 @@ class GeoIPLookup:
             if self.api_key:
                 params["token"] = self.api_key
 
-            response = requests.get(url, params=params, timeout=10)
+            proxies = get_proxies()
+            response = requests.get(
+                url,
+                params=params,
+                timeout=10,
+                proxies=proxies,  # Add this line
+            )
 
             if response.status_code == 200:
                 data = response.json()
@@ -319,7 +326,14 @@ class WebsiteAnalyzer:
         }
 
         try:
-            response = requests.get(url, headers=headers, timeout=15, allow_redirects=True)
+            proxies = get_proxies()
+            response = requests.get(
+                url,
+                headers=headers,
+                timeout=15,
+                allow_redirects=True,
+                proxies=proxies,  # Add this line
+            )
             html = response.text
 
             result["headers"] = {

--- a/modules/github_recon.py
+++ b/modules/github_recon.py
@@ -50,7 +50,7 @@ class GitHubRecon:
                 f"{self.BASE_URL}/users/{username}",
                 headers=self._headers(),
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 404:
                 result["error"] = "GitHub user not found"
@@ -114,7 +114,7 @@ class GitHubRecon:
                 headers=self._headers(),
                 params={"per_page": 100, "sort": "pushed"},
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 return r.json()
@@ -130,7 +130,7 @@ class GitHubRecon:
                 f"{self.BASE_URL}/users/{username}/events/public",
                 headers=self._headers(),
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code != 200:
                 return emails

--- a/modules/github_recon.py
+++ b/modules/github_recon.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append('..')
 from config import Colors
 from modules.module_status import annotate, print_status_notice, OK, RATE_LIMITED, ERROR
+from modules import get_proxies
 
 GITHUB_TOKEN = os.getenv("GITHUB_TOKEN", "")
 
@@ -44,7 +45,13 @@ class GitHubRecon:
             return annotate(result, ERROR, "No username provided")
 
         try:
-            r = requests.get(f"{self.BASE_URL}/users/{username}", headers=self._headers(), timeout=15)
+            proxies = get_proxies()
+            r = requests.get(
+                f"{self.BASE_URL}/users/{username}",
+                headers=self._headers(),
+                timeout=15,
+                proxies=proxies,  # Add this line
+            )
             if r.status_code == 404:
                 result["error"] = "GitHub user not found"
                 return result
@@ -101,11 +108,13 @@ class GitHubRecon:
 
     def _get_repos(self, username: str) -> List[Dict[str, Any]]:
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{self.BASE_URL}/users/{username}/repos",
                 headers=self._headers(),
                 params={"per_page": 100, "sort": "pushed"},
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 return r.json()
@@ -116,10 +125,12 @@ class GitHubRecon:
     def _emails_from_events(self, username: str) -> List[str]:
         emails: List[str] = []
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{self.BASE_URL}/users/{username}/events/public",
                 headers=self._headers(),
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
             if r.status_code != 200:
                 return emails

--- a/modules/gravatar.py
+++ b/modules/gravatar.py
@@ -52,7 +52,7 @@ class GravatarRecon:
                 f"{self.BASE_URL}/{email_hash}.json",
                 headers=self._headers(),
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if r.status_code == 404:

--- a/modules/gravatar.py
+++ b/modules/gravatar.py
@@ -2,6 +2,7 @@ import hashlib
 from typing import Dict, Any, List
 import requests
 import sys
+from modules import get_proxies
 
 sys.path.append("..")
 
@@ -46,10 +47,12 @@ class GravatarRecon:
 
         email_hash = hashlib.sha256(email.encode("utf-8")).hexdigest()
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{self.BASE_URL}/{email_hash}.json",
                 headers=self._headers(),
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
 
             if r.status_code == 404:

--- a/modules/hlr_lookup.py
+++ b/modules/hlr_lookup.py
@@ -104,7 +104,7 @@ class HLRLookup:
                     url,
                     params=params,
                     timeout=10,
-                    proxies=proxies,  # Add this line
+                    proxies=proxies,  
                 )
                 if response.status_code != 200:
                     return None
@@ -165,7 +165,7 @@ class HLRLookup:
                 f"https://api.numlookupapi.com/v1/validate/{clean}",
                 headers={"User-Agent": "OSINT-Toolkit/2.0"},
                 timeout=10,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 data = r.json()
@@ -197,7 +197,7 @@ class HLRLookup:
                         site_url,
                         headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"},
                         timeout=8,
-                        proxies=proxies,  # Add this line
+                        proxies=proxies,  
                     )
                     if r.status_code == 200:
                         text = r.text

--- a/modules/hlr_lookup.py
+++ b/modules/hlr_lookup.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, Optional
 import sys
 sys.path.append('..')
 from config import NUMVERIFY_API_KEY, Colors
+from modules import get_proxies
 
 
 class HLRLookup:
@@ -98,7 +99,13 @@ class HLRLookup:
         fallback = self.numverify_url.replace("https://", "http://", 1)
         for url in (self.numverify_url, fallback):
             try:
-                response = requests.get(url, params=params, timeout=10)
+                proxies = get_proxies()
+                response = requests.get(
+                    url,
+                    params=params,
+                    timeout=10,
+                    proxies=proxies,  # Add this line
+                )
                 if response.status_code != 200:
                     return None
                 data = response.json()
@@ -153,10 +160,12 @@ class HLRLookup:
         clean = phone.replace("+", "").replace(" ", "").replace("-", "").replace("(", "").replace(")", "")
 
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"https://api.numlookupapi.com/v1/validate/{clean}",
                 headers={"User-Agent": "OSINT-Toolkit/2.0"},
                 timeout=10,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 data = r.json()
@@ -183,10 +192,12 @@ class HLRLookup:
             ]:
                 try:
                     import re
+                    proxies = get_proxies()
                     r = requests.get(
                         site_url,
                         headers={"User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"},
                         timeout=8,
+                        proxies=proxies,  # Add this line
                     )
                     if r.status_code == 200:
                         text = r.text

--- a/modules/hudsonrock.py
+++ b/modules/hudsonrock.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from typing import Any, Dict, List, Optional
+from modules import get_proxies
 
 import requests
 
@@ -39,18 +40,19 @@ class HudsonRockLookup:
     def _headers(self) -> Dict[str, str]:
         return {"Accept": "application/json", "User-Agent": "PRISM-OSINT"}
 
-    def _proxies(self) -> Optional[Dict[str, str]]:
-        proxy = os.getenv("MODULE_PROXY", "").strip()
-        return {"http": proxy, "https": proxy} if proxy else None
+    # def _proxies(self) -> Optional[Dict[str, str]]:
+    #     proxy = os.getenv("MODULE_PROXY", "").strip()
+    #     return {"http": proxy, "https": proxy} if proxy else None
 
     def _request(self, path: str, params: Dict[str, str], result: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{self.BASE_URL}/{path}",
                 params=params,
                 headers=self._headers(),
                 timeout=self.TIMEOUT,
-                proxies=self._proxies(),
+                proxies=proxies,
             )
         except requests.Timeout:
             annotate(result, ERROR, f"Hudson Rock did not respond within {self.TIMEOUT}s")

--- a/modules/hunter.py
+++ b/modules/hunter.py
@@ -5,6 +5,7 @@ from typing import Dict, Any, List, Optional
 import sys
 sys.path.append('..')
 from config import Colors
+from modules import get_proxies
 
 FREE_PROVIDERS = {
     "gmail.com", "yahoo.com", "hotmail.com", "outlook.com", "aol.com",
@@ -51,9 +52,11 @@ class EmailRepLookup:
 
     def _check_disposable(self, domain: str) -> bool:
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"https://open.kickbox.com/v1/disposable/{domain}",
                 timeout=8,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 return r.json().get("disposable", False)

--- a/modules/hunter.py
+++ b/modules/hunter.py
@@ -56,7 +56,7 @@ class EmailRepLookup:
             r = requests.get(
                 f"https://open.kickbox.com/v1/disposable/{domain}",
                 timeout=8,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 return r.json().get("disposable", False)

--- a/modules/leak_lookup.py
+++ b/modules/leak_lookup.py
@@ -43,7 +43,7 @@ class LeakLookup:
                 headers=headers,
                 params={"truncateResponse": "false"},
                 timeout=10,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if response.status_code == 200:
@@ -95,7 +95,7 @@ class LeakLookup:
                 f"{self.XON_API}/check-email/{email}",
                 headers={"User-Agent": "OSINT-Tool"},
                 timeout=10,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if response.status_code == 200:
@@ -140,7 +140,7 @@ class LeakLookup:
                 params={"check": email},
                 headers={"User-Agent": "Mozilla/5.0 (compatible; PRISM-OSINT)"},
                 timeout=10,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if response.status_code == 200:
@@ -185,7 +185,7 @@ class LeakLookup:
             response = requests.get(
                 f"https://api.pwnedpasswords.com/range/{prefix}",
                 timeout=10,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if response.status_code == 200:
@@ -226,7 +226,7 @@ class LeakLookup:
                     "query": query
                 },
                 timeout=30,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if response.status_code == 200:

--- a/modules/leak_lookup.py
+++ b/modules/leak_lookup.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append('..')
 from config import LEAK_LOOKUP_API_KEY, HIBP_API_KEY, Colors
 from modules.module_status import annotate, classify, print_status_notice, OK, SKIPPED, RATE_LIMITED, ERROR
+from modules import get_proxies
 
 
 class LeakLookup:
@@ -36,11 +37,13 @@ class LeakLookup:
         }
 
         try:
+            proxies = get_proxies()
             response = requests.get(
                 f"{self.HIBP_API}/breachedaccount/{email}",
                 headers=headers,
                 params={"truncateResponse": "false"},
-                timeout=10
+                timeout=10,
+                proxies=proxies,  # Add this line
             )
 
             if response.status_code == 200:
@@ -87,10 +90,12 @@ class LeakLookup:
         }
 
         try:
+            proxies = get_proxies()
             response = requests.get(
                 f"{self.XON_API}/check-email/{email}",
                 headers={"User-Agent": "OSINT-Tool"},
-                timeout=10
+                timeout=10,
+                proxies=proxies,  # Add this line
             )
 
             if response.status_code == 200:
@@ -129,11 +134,13 @@ class LeakLookup:
         }
 
         try:
+            proxies = get_proxies()
             response = requests.get(
                 self.LEAKCHECK_PUBLIC,
                 params={"check": email},
                 headers={"User-Agent": "Mozilla/5.0 (compatible; PRISM-OSINT)"},
-                timeout=10
+                timeout=10,
+                proxies=proxies,  # Add this line
             )
 
             if response.status_code == 200:
@@ -174,9 +181,11 @@ class LeakLookup:
         suffix = sha1_hash[5:]
 
         try:
+            proxies = get_proxies()
             response = requests.get(
                 f"https://api.pwnedpasswords.com/range/{prefix}",
-                timeout=10
+                timeout=10,
+                proxies=proxies,  # Add this line
             )
 
             if response.status_code == 200:
@@ -208,6 +217,7 @@ class LeakLookup:
             return annotate(result, SKIPPED, "No API key configured (LEAK_LOOKUP_API_KEY)")
 
         try:
+            proxies = get_proxies()
             response = requests.post(
                 self.LEAK_LOOKUP_API,
                 data={
@@ -215,7 +225,8 @@ class LeakLookup:
                     "type": query_type,
                     "query": query
                 },
-                timeout=30
+                timeout=30,
+                proxies=proxies,  # Add this line
             )
 
             if response.status_code == 200:

--- a/modules/lunar.py
+++ b/modules/lunar.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from typing import Any, Dict, List, Optional
+from modules import get_proxies
 
 import requests
 
@@ -43,18 +44,19 @@ class LunarLookup:
     def _headers(self) -> Dict[str, str]:
         return {"Accept": "application/json", "User-Agent": "PRISM-OSINT"}
 
-    def _proxies(self) -> Optional[Dict[str, str]]:
-        proxy = os.getenv("MODULE_PROXY", "").strip()
-        return {"http": proxy, "https": proxy} if proxy else None
+    # def _proxies(self) -> Optional[Dict[str, str]]:
+    #     proxy = os.getenv("MODULE_PROXY", "").strip()
+    #     return {"http": proxy, "https": proxy} if proxy else None
 
     def _request(self, domain: str, result: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         try:
+            proxies = get_proxies()
             r = requests.get(
                 self.BASE_URL,
                 params={"domain": domain},
                 headers=self._headers(),
                 timeout=self.TIMEOUT,
-                proxies=self._proxies(),
+                proxies=proxies,
             )
         except requests.Timeout:
             annotate(result, ERROR, f"Lunar did not respond within {self.TIMEOUT}s")

--- a/modules/qr_decoder.py
+++ b/modules/qr_decoder.py
@@ -1,5 +1,6 @@
 import requests
 from typing import Dict, Any, Optional, Tuple
+from modules import get_proxies
 
 
 class QRDecoder:
@@ -22,10 +23,12 @@ class QRDecoder:
 
     def _decode_api(self, image_bytes: bytes, filename: str) -> Tuple[Optional[str], Optional[str]]:
         try:
+            proxies = get_proxies()
             r = requests.post(
                 "https://api.qrserver.com/v1/read-qr-code/",
                 files={"file": (filename, image_bytes)},
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
             if r.status_code != 200:
                 return None, f"API returned HTTP {r.status_code}"

--- a/modules/qr_decoder.py
+++ b/modules/qr_decoder.py
@@ -28,7 +28,7 @@ class QRDecoder:
                 "https://api.qrserver.com/v1/read-qr-code/",
                 files={"file": (filename, image_bytes)},
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code != 200:
                 return None, f"API returned HTTP {r.status_code}"

--- a/modules/rdap.py
+++ b/modules/rdap.py
@@ -1,6 +1,7 @@
 import ipaddress
 import re
 from typing import Any, Dict, List, Optional
+from modules import get_proxies
 
 import requests
 
@@ -127,10 +128,12 @@ class RDAPLookup:
         result["rdap_url"] = rdap_url
 
         try:
+            proxies = get_proxies()
             r = requests.get(
                 rdap_url,
                 timeout=self.timeout,
                 headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 404:
                 if not self._tld_served(domain):
@@ -152,6 +155,7 @@ class RDAPLookup:
                                 location,
                                 timeout=self.timeout,
                                 headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
+                                proxies=proxies,  # Add this line
                             )
                             if r2.status_code == 200:
                                 r = r2

--- a/modules/rdap.py
+++ b/modules/rdap.py
@@ -20,7 +20,12 @@ class RDAPLookup:
         if self._bootstrap_cache is not None:
             return self._bootstrap_cache
         try:
-            r = requests.get(IANA_BOOTSTRAP_URL, timeout=self.timeout)
+            proxies = get_proxies()  
+            r = requests.get(
+                IANA_BOOTSTRAP_URL,
+                timeout=self.timeout,
+                proxies=proxies, 
+            )
             if r.status_code != 200:
                 return {}
             data = r.json()
@@ -133,7 +138,7 @@ class RDAPLookup:
                 rdap_url,
                 timeout=self.timeout,
                 headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 404:
                 if not self._tld_served(domain):
@@ -155,7 +160,7 @@ class RDAPLookup:
                                 location,
                                 timeout=self.timeout,
                                 headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
-                                proxies=proxies,  # Add this line
+                                proxies=proxies,  
                             )
                             if r2.status_code == 200:
                                 r = r2

--- a/modules/shodan_lookup.py
+++ b/modules/shodan_lookup.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append('..')
 from config import Colors, SHODAN_API_KEY
 from modules.module_status import annotate, print_status_notice, OK, SKIPPED, RATE_LIMITED, ERROR
+from modules import get_proxies
 
 
 class ShodanLookup:
@@ -25,7 +26,12 @@ class ShodanLookup:
 
     def _internetdb(self, ip: str, result: Dict[str, Any], reason: str) -> Dict[str, Any]:
         try:
-            r = requests.get(f"{self.INTERNETDB_URL}/{ip}", timeout=15)
+            proxies = get_proxies()
+            r = requests.get(
+                f"{self.INTERNETDB_URL}/{ip}",
+                timeout=15,
+                proxies=proxies,  # Add this line
+            )
         except Exception as e:
             return annotate(result, SKIPPED, f"{reason}; the free InternetDB dataset was unreachable ({str(e)[:80]})")
 
@@ -81,10 +87,12 @@ class ShodanLookup:
             return self._internetdb(ip, result, "No API key configured (SHODAN_API_KEY)")
 
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{self.BASE_URL}/shodan/host/{ip}",
                 params={"key": self.api_key},
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
 
             if r.status_code == 404:
@@ -153,10 +161,12 @@ class ShodanLookup:
             return annotate(result, SKIPPED, "No API key configured (SHODAN_API_KEY)")
 
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{self.BASE_URL}/shodan/host/search",
                 params={"key": self.api_key, "query": query, "limit": limit},
                 timeout=20,
+                proxies=proxies,  # Add this line
             )
 
             if r.status_code == 403:

--- a/modules/shodan_lookup.py
+++ b/modules/shodan_lookup.py
@@ -30,7 +30,7 @@ class ShodanLookup:
             r = requests.get(
                 f"{self.INTERNETDB_URL}/{ip}",
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
         except Exception as e:
             return annotate(result, SKIPPED, f"{reason}; the free InternetDB dataset was unreachable ({str(e)[:80]})")
@@ -92,7 +92,7 @@ class ShodanLookup:
                 f"{self.BASE_URL}/shodan/host/{ip}",
                 params={"key": self.api_key},
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if r.status_code == 404:
@@ -166,7 +166,7 @@ class ShodanLookup:
                 f"{self.BASE_URL}/shodan/host/search",
                 params={"key": self.api_key, "query": query, "limit": limit},
                 timeout=20,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if r.status_code == 403:

--- a/modules/telegram_lookup.py
+++ b/modules/telegram_lookup.py
@@ -5,6 +5,7 @@ import sys
 sys.path.append('..')
 from config import Colors
 from modules.module_status import annotate, print_status_notice, OK, SKIPPED, ERROR
+from modules import get_proxies
 
 
 class TelegramLookup:
@@ -32,11 +33,13 @@ class TelegramLookup:
         }
 
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"https://t.me/{username}",
                 headers=self.HEADERS,
                 timeout=12,
                 allow_redirects=True,
+                proxies=proxies,  # Add this line
             )
 
             if r.status_code == 404:
@@ -102,10 +105,12 @@ class TelegramLookup:
 
         if bot_token:
             try:
+                proxies = get_proxies()
                 r = requests.get(
                     f"https://api.telegram.org/bot{bot_token}/getChat",
                     params={"chat_id": tg_id},
                     timeout=10,
+                    proxies=proxies,  # Add this line
                 )
                 data = r.json()
                 if data.get("ok") and data.get("result"):

--- a/modules/telegram_lookup.py
+++ b/modules/telegram_lookup.py
@@ -39,7 +39,7 @@ class TelegramLookup:
                 headers=self.HEADERS,
                 timeout=12,
                 allow_redirects=True,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if r.status_code == 404:
@@ -110,7 +110,7 @@ class TelegramLookup:
                     f"https://api.telegram.org/bot{bot_token}/getChat",
                     params={"chat_id": tg_id},
                     timeout=10,
-                    proxies=proxies,  # Add this line
+                    proxies=proxies,  
                 )
                 data = r.json()
                 if data.get("ok") and data.get("result"):

--- a/modules/threat_intel.py
+++ b/modules/threat_intel.py
@@ -4,6 +4,7 @@ import sys
 sys.path.append('..')
 from config import Colors, VIRUSTOTAL_API_KEY, ABUSEIPDB_API_KEY
 from modules.module_status import annotate, print_status_notice, OK, SKIPPED, RATE_LIMITED, ERROR
+from modules import get_proxies
 
 
 class VirusTotal:
@@ -18,10 +19,12 @@ class VirusTotal:
         if not self.api_key:
             return annotate({}, SKIPPED, "No API key configured (VIRUSTOTAL_API_KEY)")
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{self.BASE_URL}{endpoint}",
                 headers=self.headers,
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 return r.json()
@@ -91,11 +94,13 @@ class VirusTotal:
                 "No API key configured (VIRUSTOTAL_API_KEY)",
             )
         try:
+            proxies = get_proxies()
             submit_r = requests.post(
                 f"{self.BASE_URL}/urls",
                 headers=self.headers,
                 data={"url": url},
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
             if submit_r.status_code == 429:
                 return annotate(
@@ -113,6 +118,7 @@ class VirusTotal:
                 f"{self.BASE_URL}/analyses/{analysis_id}",
                 headers=self.headers,
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
             if result_r.status_code != 200:
                 return {"query": url, "type": "url", "error": f"Results fetch failed: {result_r.status_code}"}
@@ -196,11 +202,13 @@ class AbuseIPDB:
             return annotate(result, SKIPPED, "No API key configured (ABUSEIPDB_API_KEY)")
 
         try:
+            proxies = get_proxies()
             r = requests.get(
                 f"{self.BASE_URL}/check",
                 headers=self.headers,
                 params={"ipAddress": ip, "maxAgeInDays": max_age_days, "verbose": True},
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 data = r.json().get("data", {})

--- a/modules/threat_intel.py
+++ b/modules/threat_intel.py
@@ -24,7 +24,7 @@ class VirusTotal:
                 f"{self.BASE_URL}{endpoint}",
                 headers=self.headers,
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 return r.json()
@@ -100,7 +100,7 @@ class VirusTotal:
                 headers=self.headers,
                 data={"url": url},
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if submit_r.status_code == 429:
                 return annotate(
@@ -118,7 +118,7 @@ class VirusTotal:
                 f"{self.BASE_URL}/analyses/{analysis_id}",
                 headers=self.headers,
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if result_r.status_code != 200:
                 return {"query": url, "type": "url", "error": f"Results fetch failed: {result_r.status_code}"}
@@ -208,7 +208,7 @@ class AbuseIPDB:
                 headers=self.headers,
                 params={"ipAddress": ip, "maxAgeInDays": max_age_days, "verbose": True},
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 data = r.json().get("data", {})

--- a/modules/url_scanner.py
+++ b/modules/url_scanner.py
@@ -2,6 +2,7 @@ import base64
 import time
 import requests
 from typing import Dict, Any
+from modules import get_proxies
 
 import sys, os
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -31,11 +32,13 @@ class URLScanner:
         headers = {"x-apikey": VIRUSTOTAL_API_KEY}
 
         try:
+            proxies = get_proxies()
             r = requests.post(
                 f"{self.VT_BASE}/urls",
                 headers=headers,
                 data={"url": url},
                 timeout=15,
+                proxies=proxies,  # Add this line
             )
             if r.status_code not in (200, 201):
                 result["error"] = f"Submit failed: HTTP {r.status_code}"
@@ -56,6 +59,7 @@ class URLScanner:
                     f"{self.VT_BASE}/analyses/{analysis_id}",
                     headers=headers,
                     timeout=15,
+                    proxies=proxies,  # Add this line
                 )
                 data = r2.json().get("data", {})
                 attrs = data.get("attributes", {})

--- a/modules/url_scanner.py
+++ b/modules/url_scanner.py
@@ -38,7 +38,7 @@ class URLScanner:
                 headers=headers,
                 data={"url": url},
                 timeout=15,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code not in (200, 201):
                 result["error"] = f"Submit failed: HTTP {r.status_code}"
@@ -59,7 +59,7 @@ class URLScanner:
                     f"{self.VT_BASE}/analyses/{analysis_id}",
                     headers=headers,
                     timeout=15,
-                    proxies=proxies,  # Add this line
+                    proxies=proxies,  
                 )
                 data = r2.json().get("data", {})
                 attrs = data.get("attributes", {})

--- a/modules/wayback.py
+++ b/modules/wayback.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import sys
 sys.path.append('..')
 from config import Colors
+from modules import get_proxies
 
 
 class WaybackMachine:
@@ -30,7 +31,13 @@ class WaybackMachine:
                 "filter": "statuscode:200",
                 "collapse": "timestamp:8",
             }
-            r = requests.get(self.CDX_URL, params=params, timeout=45)
+            proxies = get_proxies()
+            r = requests.get(
+                self.CDX_URL,
+                params=params,
+                timeout=45,
+                proxies=proxies,  # Add this line
+            )
 
             if r.status_code != 200:
                 result["error"] = f"CDX API returned {r.status_code}"
@@ -107,7 +114,13 @@ class WaybackMachine:
                 "collapse": "urlkey",
                 "filter": "statuscode:200",
             }
-            r = requests.get(self.CDX_URL, params=params, timeout=25)
+            proxies = get_proxies()
+            r = requests.get(
+                self.CDX_URL,
+                params=params,
+                timeout=25,
+                proxies=proxies,  # Add this line
+            )
 
             if r.status_code != 200:
                 result["error"] = f"CDX API returned {r.status_code}"
@@ -137,10 +150,12 @@ class WaybackMachine:
     def check_availability(self, url: str) -> Dict[str, Any]:
         result = {"url": url, "available": False, "closest_snapshot": None, "error": None}
         try:
+            proxies = get_proxies()
             r = requests.get(
                 self.AVAILABILITY_URL,
                 params={"url": url},
                 timeout=10,
+                proxies=proxies,  # Add this line
             )
             if r.status_code == 200:
                 data = r.json()

--- a/modules/wayback.py
+++ b/modules/wayback.py
@@ -36,7 +36,7 @@ class WaybackMachine:
                 self.CDX_URL,
                 params=params,
                 timeout=45,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if r.status_code != 200:
@@ -119,7 +119,7 @@ class WaybackMachine:
                 self.CDX_URL,
                 params=params,
                 timeout=25,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
 
             if r.status_code != 200:
@@ -155,7 +155,7 @@ class WaybackMachine:
                 self.AVAILABILITY_URL,
                 params={"url": url},
                 timeout=10,
-                proxies=proxies,  # Add this line
+                proxies=proxies,  
             )
             if r.status_code == 200:
                 data = r.json()

--- a/tests/test_hudsonrock.py
+++ b/tests/test_hudsonrock.py
@@ -166,3 +166,13 @@ def test_no_proxy_by_default(enabled, monkeypatch):
     with patch("modules.hudsonrock.requests.get", return_value=FakeResponse(payload=DOMAIN_PAYLOAD)) as mock_get:
         HudsonRockLookup().search_domain("example.com")
     assert mock_get.call_args.kwargs["proxies"] is None
+
+def test_get_proxies_returns_none_when_not_set(monkeypatch):
+    from modules import get_proxies
+    monkeypatch.delenv("MODULE_PROXY", raising=False)
+    assert get_proxies() is None
+
+def test_get_proxies_returns_dict_when_set(monkeypatch):
+    from modules import get_proxies
+    monkeypatch.setenv("MODULE_PROXY", "http://proxy:8080")
+    assert get_proxies() == {"http": "http://proxy:8080", "https": "http://proxy:8080"}

--- a/tests/test_rdap.py
+++ b/tests/test_rdap.py
@@ -220,3 +220,43 @@ def test_rdap_lookup_tld_without_rdap(monkeypatch):
         result = rdap.lookup("sberbank.ru")
         assert classify(result) == SKIPPED
         assert result["registered"] is None
+
+
+def test_rdap_calls_get_proxies_for_every_request(monkeypatch):
+    """Verify RDAP calls get_proxies() for both bootstrap and lookup requests."""
+    from modules import rdap as rdap_module
+    
+    get_proxies_call_count = 0
+    proxy_value = {"http": "http://proxy.test:8080", "https": "http://proxy.test:8080"}
+    
+    def mock_get_proxies():
+        nonlocal get_proxies_call_count
+        get_proxies_call_count += 1
+        return proxy_value
+    
+    monkeypatch.setattr(rdap_module, "get_proxies", mock_get_proxies)
+    
+    # Track proxy usage in each request
+    proxy_used_in_requests = []
+    
+    def mock_requests_get(*args, **kwargs):
+        proxy_used_in_requests.append(kwargs.get("proxies"))
+        # Return different responses based on URL
+        if "data.iana.org" in args[0]:
+            return FakeResponse(200, {"services": [[["com"], ["https://rdap.verisign.com/com/v1/"]]]})
+        else:
+            return FakeResponse(200, REGISTERED_RESPONSE)
+    
+    monkeypatch.setattr(rdap_module.requests, "get", mock_requests_get)
+    
+    rdap = RDAPLookup()
+    rdap.lookup("example.com")
+    
+    # get_proxies should have been called at least once
+    assert get_proxies_call_count > 0, "get_proxies() was never called"
+    
+    # Every request should have received the proxy
+    assert len(proxy_used_in_requests) >= 2, "Expected at least 2 requests (bootstrap + lookup)"
+    for proxies in proxy_used_in_requests:
+        assert proxies == proxy_value, f"Request did not use the proxy: {proxies}"
+


### PR DESCRIPTION
Previously only hudsonrock and lunar respected MODULE_PROXY. The other 20 modules that make outbound HTTP requests ignored it, which meant users who set a proxy for OSINT work were leaking their real IP from most modules while thinking they were covered.

This change:
- Adds get_proxies() helper to modules/__init__.py
- Updates every module using requests.get/post to pass proxies=
- Removes duplicate _proxies() methods from hudsonrock and lunar
- Leaves onion_checker.py unchanged (needs SOCKS proxy for Tor)

Modules updated: censys, cert_transparency, crypto, darkweb, github, gravatar, hlr, hudsonrock, hunter, leak_lookup, lunar, rdap, shodan, telegram, threat_intel (VirusTotal & AbuseIPDB), url_scanner, wayback, extra_tools (GeoIP & WebsiteAnalyzer), qr_decoder

Closes #324

## Summary
<!-- Describe your changes briefly -->

## Changes
<!-- List specific changes -->
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
