### PR TITLE
Add scan this page action to extension

### DIFF
--- a/extension/_locales/de/messages.json
+++ b/extension/_locales/de/messages.json
@@ -26,6 +26,15 @@
   "saveButton": {
     "message": "Speichern"
   },
+  "scanPageButton": {
+    "message": "Diese Seite scannen"
+  },
+  "scanPageUnsupported": {
+    "message": "Diese Seite kann nicht gescannt werden."
+  },
+  "scanPageHostname": {
+    "message": "Der Hostname der Seite konnte nicht ermittelt werden."
+  },
   "savedOk": {
     "message": "Gespeichert"
   },

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -17,6 +17,15 @@
   "scanButton": {
     "message": "Scan"
   },
+  "scanPageButton": {
+    "message": "Scan this page"
+  },
+  "scanPageUnsupported": {
+    "message": "This page cannot be scanned."
+  },
+  "scanPageHostname": {
+    "message": "Could not determine the page hostname."
+  },
   "serverLabel": {
     "message": "Server"
   },

--- a/extension/_locales/es/messages.json
+++ b/extension/_locales/es/messages.json
@@ -17,6 +17,15 @@
   "scanButton": {
     "message": "Escanear"
   },
+  "scanPageButton": {
+    "message": "Escanear esta página"
+  },
+  "scanPageUnsupported": {
+    "message": "Esta página no se puede escanear."
+  },
+  "scanPageHostname": {
+    "message": "No se pudo determinar el nombre de host de la página."
+  },
   "serverLabel": {
     "message": "Servidor"
   },

--- a/extension/_locales/fr/messages.json
+++ b/extension/_locales/fr/messages.json
@@ -17,6 +17,15 @@
   "scanButton": {
     "message": "Scanner"
   },
+  "scanPageButton": {
+    "message": "Analyser cette page"
+  },
+  "scanPageUnsupported": {
+    "message": "Cette page ne peut pas être analysée."
+  },
+  "scanPageHostname": {
+    "message": "Impossible de déterminer le nom d’hôte de la page."
+  },
   "serverLabel": {
     "message": "Serveur"
   },

--- a/extension/_locales/it/messages.json
+++ b/extension/_locales/it/messages.json
@@ -17,6 +17,15 @@
   "scanButton": {
     "message": "Analizza"
   },
+  "scanPageButton": {
+   "message": "Scansiona questa pagina"
+  },
+  "scanPageUnsupported": {
+    "message": "Questa pagina non può essere scansionata."
+  },
+  "scanPageHostname": {
+  "message": "Impossibile determinare il nome host della pagina."
+  },
   "serverLabel": {
     "message": "Server"
   },

--- a/extension/_locales/pl/messages.json
+++ b/extension/_locales/pl/messages.json
@@ -17,6 +17,15 @@
   "scanButton": {
     "message": "Skanuj"
   },
+  "scanPageButton": {
+    "message": "Skanuj tę stronę"
+  },
+  "scanPageUnsupported": {
+    "message": "Tej strony nie można przeskanować."
+  },
+  "scanPageHostname": {
+    "message": "Nie można określić nazwy hosta strony."
+  },
   "serverLabel": {
     "message": "Serwer"
   },

--- a/extension/_locales/pt/messages.json
+++ b/extension/_locales/pt/messages.json
@@ -17,6 +17,15 @@
   "scanButton": {
     "message": "Verificar"
   },
+  "scanPageButton": {
+    "message": "Verificar esta página"
+  },
+  "scanPageUnsupported": {
+    "message": "Esta página não pode ser verificada."
+  },
+  "scanPageHostname": {
+    "message": "Não foi possível determinar o nome do host da página."
+  },
   "serverLabel": {
     "message": "Servidor"
   },

--- a/extension/_locales/ru/messages.json
+++ b/extension/_locales/ru/messages.json
@@ -17,6 +17,15 @@
   "scanButton": {
     "message": "Сканировать"
   },
+  "scanPageButton": {
+    "message": "Сканировать эту страницу"
+  },
+  "scanPageUnsupported": {
+    "message": "Эту страницу нельзя просканировать."
+  },
+  "scanPageHostname": {
+    "message": "Не удалось определить имя хоста страницы."
+  },
   "serverLabel": {
     "message": "Сервер"
   },

--- a/extension/_locales/zh_CN/messages.json
+++ b/extension/_locales/zh_CN/messages.json
@@ -17,6 +17,15 @@
   "scanButton": {
     "message": "扫描"
   },
+  "scanPageButton": {
+    "message": "扫描此页面"
+  },
+  "scanPageUnsupported": {
+    "message": "无法扫描此页面。"
+  },
+  "scanPageHostname": {
+    "message": "无法确定页面主机名。"
+  },
   "serverLabel": {
     "message": "服务器"
   },

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,7 +11,8 @@
   },
   "permissions": [
     "contextMenus",
-    "storage"
+    "storage",
+    "tabs"
   ],
   "host_permissions": [
     "http://*/*",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -11,8 +11,7 @@
   },
   "permissions": [
     "contextMenus",
-    "storage",
-    "tabs"
+    "storage"
   ],
   "host_permissions": [
     "http://*/*",

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -15,7 +15,7 @@
       <input id="target" data-i18n-ph="targetPlaceholder" placeholder="domain, IP, email, phone, username" />
       <div id="recentTargets" class="recent-targets" hidden></div>
       <button id="scan" class="primary" data-i18n="scanButton">Scan</button>
-      <button id="scanPage" class="ghost">Scan this page</button>
+      <button id="scanPage" class="ghost" data-i18n="scanPageButton">Scan this page</button>
       <hr />
 
       <label for="url" data-i18n="serverLabel">Server</label>

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -15,7 +15,7 @@
       <input id="target" data-i18n-ph="targetPlaceholder" placeholder="domain, IP, email, phone, username" />
       <div id="recentTargets" class="recent-targets" hidden></div>
       <button id="scan" class="primary" data-i18n="scanButton">Scan</button>
-
+      <button id="scanPage" class="ghost">Scan this page</button>
       <hr />
 
       <label for="url" data-i18n="serverLabel">Server</label>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -125,12 +125,12 @@ async function runPageScan() {
 
   const url = new URL(tab.url);
 
-  if (["chrome:", "about:", "file:"].includes(url.protocol)) {
-    return fail("This page cannot be scanned.");
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+  return fail(t("scanPageUnsupported", "This page cannot be scanned."));
   }
 
   const target = url.hostname;
-  if (!target) return fail("Could not determine the page hostname.");
+  if (!target) return fail(t("scanPageHostname", "Could not determine the page hostname."));
 
   const server = baseUrl(urlInput.value);
   const apiKey = keyInput.value.trim();

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -114,7 +114,37 @@ function runScan() {
   saveRecentTarget(target);
   start(target, server, apiKey);
 }
+async function runPageScan() {
+  const tabs = await chrome.tabs.query({
+    active: true,
+    currentWindow: true
+  });
+
+  const tab = tabs[0];
+  if (!tab || !tab.url) return;
+
+  const url = new URL(tab.url);
+
+  if (["chrome:", "about:", "file:"].includes(url.protocol)) {
+    return fail("This page cannot be scanned.");
+  }
+
+  const target = url.hostname;
+  if (!target) return fail("Could not determine the page hostname.");
+
+  const server = baseUrl(urlInput.value);
+  const apiKey = keyInput.value.trim();
+
+  chrome.storage.sync.set({
+    instanceUrl: urlInput.value.trim(),
+    apiKey
+  });
+
+  saveRecentTarget(target);
+  start(target, server, apiKey);
+}
 $("scan").addEventListener("click", runScan);
+$("scanPage").addEventListener("click", runPageScan);
 targetInput.addEventListener("keydown", (e) => { if (e.key === "Enter") runScan(); });
 
 function setStatus(text, cls) { statusEl.textContent = text; statusEl.className = "status" + (cls ? " " + cls : ""); }


### PR DESCRIPTION
## Summary
Added a "Scan this page" action to the browser extension popup. The feature reads the active tab URL, extracts the hostname, and starts a PRISM scan using the existing scan flow.

## Changes
- Added a "Scan this page" button to the extension popup
- Added active-tab URL detection using `chrome.tabs.query()`
- Extracted the hostname from the active page URL
- Reused the existing `start()` scan function
- Added handling to skip `chrome://`, `about:`, and `file://` pages
- Added the `tabs` permission to the extension manifest

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [x] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
Tested the "Scan this page" action on `https://example.com` and confirmed that the hostname `example.com` is scanned successfully.