### PR TITLE
Send one User-Agent instead of ten

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -13,8 +13,9 @@ if _PROJECT_ROOT not in sys.path:
     sys.path.insert(0, _PROJECT_ROOT)
 
 import config
+from config import PRISM_VERSION
 
-__version__ = "2.8.1"
+__version__ = PRISM_VERSION
 
 
 def normalize_target(target: str) -> str:

--- a/config.py
+++ b/config.py
@@ -18,6 +18,11 @@ CENSYS_API_SECRET = os.getenv("CENSYS_API_SECRET", "")
 OUTPUT_DIR = os.path.join(os.path.dirname(__file__), "results")
 os.makedirs(OUTPUT_DIR, exist_ok=True)
 
+# Single outbound identity for all modules. Kept in one place so version bumps
+# don't leave half the modules announcing a stale release.
+PRISM_VERSION = "2.8.1"
+USER_AGENT = f"PRISM-OSINT/{PRISM_VERSION} (+https://github.com/NovaCode37/Prism-platform)"
+
 class Colors:
     RED = "\033[91m"
     GREEN = "\033[92m"

--- a/modules/censys_lookup.py
+++ b/modules/censys_lookup.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from config import USER_AGENT
 
 import os
 from typing import Any, Dict
@@ -24,7 +25,7 @@ class CensysLookup:
         return {
             "Authorization": f"Bearer {self.pat}",
             "Accept": "application/json",
-            "User-Agent": "PRISM-OSINT/2.4",
+            "User-Agent": USER_AGENT,
         }
 
     def _params(self) -> Dict[str, str]:

--- a/modules/cert_transparency.py
+++ b/modules/cert_transparency.py
@@ -2,7 +2,7 @@ import requests
 from typing import Dict, Any, List
 import sys
 sys.path.append('..')
-from config import Colors
+from config import Colors, USER_AGENT
 from modules import get_proxies
 
 
@@ -25,7 +25,7 @@ class CertTransparency:
                 self.BASE_URL,
                 params = {"q": f"%.{domain}", "output": "json", "deduplicate": "Y"},
                 timeout=30,
-                headers={"User-Agent": "OSINT-Toolkit/2.0"},
+                headers={"User-Agent": USER_AGENT},
                 proxies=proxies,  
             )
 

--- a/modules/github_recon.py
+++ b/modules/github_recon.py
@@ -3,7 +3,7 @@ import requests
 from typing import Dict, Any, List
 import sys
 sys.path.append('..')
-from config import Colors
+from config import Colors, USER_AGENT
 from modules.module_status import annotate, print_status_notice, OK, RATE_LIMITED, ERROR
 from modules import get_proxies
 
@@ -24,7 +24,7 @@ class GitHubRecon:
         self.token = GITHUB_TOKEN
 
     def _headers(self) -> Dict[str, str]:
-        headers = {"Accept": "application/vnd.github+json", "User-Agent": "PRISM-OSINT"}
+        headers = {"Accept": "application/vnd.github+json", "User-Agent": USER_AGENT}
         if self.token:
             headers["Authorization"] = f"Bearer {self.token}"
         return headers

--- a/modules/gravatar.py
+++ b/modules/gravatar.py
@@ -6,7 +6,7 @@ from modules import get_proxies
 
 sys.path.append("..")
 
-from config import Colors
+from config import Colors, USER_AGENT
 from modules.module_status import (
     annotate,
     print_status_notice,
@@ -28,7 +28,7 @@ class GravatarRecon:
     def _headers(self) -> Dict[str, str]:
         return {
             "Accept": "application/json",
-            "User-Agent": "PRISM-OSINT",
+            "User-Agent": USER_AGENT,
         }
 
     def lookup(self, email: str) -> Dict[str, Any]:

--- a/modules/hlr_lookup.py
+++ b/modules/hlr_lookup.py
@@ -4,7 +4,7 @@ from phonenumbers import carrier, geocoder, timezone
 from typing import Dict, Any, Optional
 import sys
 sys.path.append('..')
-from config import NUMVERIFY_API_KEY, Colors
+from config import Colors, NUMVERIFY_API_KEY, USER_AGENT
 from modules import get_proxies
 
 
@@ -163,7 +163,7 @@ class HLRLookup:
             proxies = get_proxies()
             r = requests.get(
                 f"https://api.numlookupapi.com/v1/validate/{clean}",
-                headers={"User-Agent": "OSINT-Toolkit/2.0"},
+                headers={"User-Agent": USER_AGENT},
                 timeout=10,
                 proxies=proxies,  
             )

--- a/modules/hudsonrock.py
+++ b/modules/hudsonrock.py
@@ -7,7 +7,7 @@ import requests
 
 sys.path.append("..")
 
-from config import Colors
+from config import Colors, USER_AGENT
 from modules.module_status import (
     annotate,
     print_status_notice,
@@ -38,7 +38,7 @@ class HudsonRockLookup:
     TIMEOUT = 25
 
     def _headers(self) -> Dict[str, str]:
-        return {"Accept": "application/json", "User-Agent": "PRISM-OSINT"}
+        return {"Accept": "application/json", "User-Agent": USER_AGENT}
 
     # def _proxies(self) -> Optional[Dict[str, str]]:
     #     proxy = os.getenv("MODULE_PROXY", "").strip()

--- a/modules/leak_lookup.py
+++ b/modules/leak_lookup.py
@@ -3,7 +3,7 @@ import hashlib
 from typing import Dict, Any, List, Optional
 import sys
 sys.path.append('..')
-from config import LEAK_LOOKUP_API_KEY, HIBP_API_KEY, Colors
+from config import Colors, HIBP_API_KEY, LEAK_LOOKUP_API_KEY, USER_AGENT
 from modules.module_status import annotate, classify, print_status_notice, OK, SKIPPED, RATE_LIMITED, ERROR
 from modules import get_proxies
 
@@ -32,7 +32,7 @@ class LeakLookup:
             return annotate(result, SKIPPED, "No API key configured (HIBP_API_KEY)")
 
         headers = {
-            "User-Agent": "OSINT-Tool",
+            "User-Agent": USER_AGENT,
             "hibp-api-key": self.hibp_key,
         }
 
@@ -93,7 +93,7 @@ class LeakLookup:
             proxies = get_proxies()
             response = requests.get(
                 f"{self.XON_API}/check-email/{email}",
-                headers={"User-Agent": "OSINT-Tool"},
+                headers={"User-Agent": USER_AGENT},
                 timeout=10,
                 proxies=proxies,  
             )
@@ -138,7 +138,7 @@ class LeakLookup:
             response = requests.get(
                 self.LEAKCHECK_PUBLIC,
                 params={"check": email},
-                headers={"User-Agent": "Mozilla/5.0 (compatible; PRISM-OSINT)"},
+                headers={"User-Agent": USER_AGENT},
                 timeout=10,
                 proxies=proxies,  
             )

--- a/modules/lunar.py
+++ b/modules/lunar.py
@@ -7,7 +7,7 @@ import requests
 
 sys.path.append("..")
 
-from config import Colors
+from config import Colors, USER_AGENT
 from modules.module_status import (
     annotate,
     print_status_notice,
@@ -42,7 +42,7 @@ class LunarLookup:
     TOP_N = 8
 
     def _headers(self) -> Dict[str, str]:
-        return {"Accept": "application/json", "User-Agent": "PRISM-OSINT"}
+        return {"Accept": "application/json", "User-Agent": USER_AGENT}
 
     # def _proxies(self) -> Optional[Dict[str, str]]:
     #     proxy = os.getenv("MODULE_PROXY", "").strip()

--- a/modules/onion_checker.py
+++ b/modules/onion_checker.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+from config import USER_AGENT
 
 import re
 from typing import Any, Dict, List, Set
@@ -45,7 +46,7 @@ class OnionChecker:
                 params={"q": query},
                 timeout=self.timeout,
                 proxies=get_proxies(),
-                headers={"User-Agent": "PRISM-OSINT/2.1"},
+                headers={"User-Agent": USER_AGENT},
             )
             if r.status_code != 200:
                 return []
@@ -73,7 +74,7 @@ class OnionChecker:
                 params={"query": query, "page": 1},
                 timeout=self.timeout,
                 proxies=get_proxies(),
-                headers={"User-Agent": "PRISM-OSINT/2.1"},
+                headers={"User-Agent": USER_AGENT},
             )
             if r.status_code != 200:
                 return []

--- a/modules/rdap.py
+++ b/modules/rdap.py
@@ -1,3 +1,4 @@
+from config import USER_AGENT
 import ipaddress
 import re
 from typing import Any, Dict, List, Optional
@@ -137,7 +138,7 @@ class RDAPLookup:
             r = requests.get(
                 rdap_url,
                 timeout=self.timeout,
-                headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
+                headers={"Accept": "application/json", "User-Agent": USER_AGENT},
                 proxies=proxies,  
             )
             if r.status_code == 404:
@@ -159,7 +160,7 @@ class RDAPLookup:
                             r2 = requests.get(
                                 location,
                                 timeout=self.timeout,
-                                headers={"Accept": "application/json", "User-Agent": "PRISM-OSINT/2.1"},
+                                headers={"Accept": "application/json", "User-Agent": USER_AGENT},
                                 proxies=proxies,  
                             )
                             if r2.status_code == 200:

--- a/tests/test_user_agent_guard.py
+++ b/tests/test_user_agent_guard.py
@@ -1,0 +1,47 @@
+"""Guard: no hardcoded User-Agent strings outside the deliberate browser ones.
+
+Issue #320 unified ten UA strings into config.USER_AGENT. This test keeps it
+that way: any new module must import USER_AGENT instead of inlining a string.
+The Mozilla/5.0 literals are intentional (some scraped sites block tool UAs)
+and are whitelisted below.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+ROOT = Path(__file__).resolve().parent.parent
+
+# Full browser strings that must stay as-is. Matched by exact literal.
+ALLOWED_LITERALS = {
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+}
+
+UA_RE = re.compile(r'"User-Agent"\s*:\s*"([^"]+)"')
+
+
+def test_no_hardcoded_user_agents():
+    offenders = []
+    for py in list((ROOT / "modules").rglob("*.py")) + list((ROOT / "web").rglob("*.py")):
+        text = py.read_text(encoding="utf-8", errors="replace")
+        for match in UA_RE.finditer(text):
+            literal = match.group(1)
+            if literal not in ALLOWED_LITERALS:
+                offenders.append(f"{py.relative_to(ROOT)}: {literal}")
+    assert not offenders, "Hardcoded User-Agent found (import USER_AGENT from config):\n" + "\n".join(
+        offenders
+    )
+
+
+def test_user_agent_tracks_version():
+    from config import PRISM_VERSION, USER_AGENT
+
+    assert PRISM_VERSION in USER_AGENT
+    import cli
+
+    assert cli.__version__ == PRISM_VERSION, "cli.__version__ drifted from config.PRISM_VERSION"

--- a/web/app.py
+++ b/web/app.py
@@ -23,6 +23,7 @@ from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 import config
+from config import USER_AGENT
 
 from modules.graph_builder import build_graph
 from modules.module_status import classify, reason_for, OK, ERROR
@@ -183,7 +184,7 @@ def _geocode_place(query: str) -> Optional[Dict]:
         r = _requests.get(
             "https://nominatim.openstreetmap.org/search",
             params={"q": query, "format": "json", "limit": 1},
-            headers={"User-Agent": "PRISM-OSINT/2.3 (https://github.com/NovaCode37/Prism-platform)"},
+            headers={"User-Agent": USER_AGENT},
             timeout=8,
         )
         arr = r.json()
@@ -389,7 +390,7 @@ def _send_webhook(url: str, payload: Dict[str, Any]) -> None:
     elif webhook_format == "discord":
         payload = format_discord(payload)
 
-    headers = {"Content-Type": "application/json", "User-Agent": "PRISM-Webhook/2.1.2"}
+    headers = {"Content-Type": "application/json", "User-Agent": USER_AGENT}
     if WEBHOOK_SECRET:
         headers["X-Prism-Secret"] = WEBHOOK_SECRET
     try:


### PR DESCRIPTION
Fixes #320.

Outbound requests were announcing ten different UAs with versions frozen between 2.0 and 2.4 while the project is on 2.8.1. Now there's one constant:

```
PRISM-OSINT/2.8.1 (+https://github.com/NovaCode37/Prism-platform)
```

built from `PRISM_VERSION` in `config.py`. `cli.py` imports the same constant for `--version`, so the UA and `--version` can't drift apart again.

Behaviour changes (all of them name PRISM, so per the issue they unify):
- `PRISM-OSINT/2.1` / `2.3` / `2.4` / bare `PRISM-OSINT` (censys, github_recon, gravatar, hudsonrock, lunar, onion_checker, rdap, web/app.py) → shared UA
- `OSINT-Toolkit/2.0` and `OSINT-Tool` (cert_transparency, hlr_lookup, leak_lookup — the pre-rename name) → shared UA
- `Mozilla/5.0 (compatible; PRISM-OSINT)` (leak_lookup) → shared UA — it identifies the tool, so it unifies like the rest, but it is technically a bot-convention string, flagging it here in case you'd rather keep it
- `PRISM-Webhook/2.1.2` (webhook delivery) → shared UA — the separate webhook version line is collapsed on purpose

Left alone: the full browser strings in blackbird, darkweb_search, extra_tools, hlr_lookup (scrape path) and telegram_lookup — those sites block tool UAs.

Also added `tests/test_user_agent_guard.py`: a scan that fails if any `modules/` or `web/` file hardcodes a UA literal outside the two whitelisted browser strings, plus a drift check that `cli.__version__ == config.PRISM_VERSION`.

Tests: `pytest tests/ -q` — 366 passed (364 existing + 2 new).