### PR TITLE
fix: clear react hooks exhaustive deps warnings

### DIFF
--- a/frontend/src/components/LoadingScreen.tsx
+++ b/frontend/src/components/LoadingScreen.tsx
@@ -78,6 +78,8 @@ function LoadingScreen({ fading, onDone }: { fading: boolean; onDone: () => void
   const [activeModules, setActiveModules] = useState<number[]>([]);
   const [bootLine, setBootLine] = useState('');
   const calledDone = useRef(false);
+  const onDoneRef = useRef(onDone);
+  onDoneRef.current = onDone;
 
   useEffect(() => {
     const progressTimer = setInterval(() => {
@@ -86,7 +88,7 @@ function LoadingScreen({ fading, onDone }: { fading: boolean; onDone: () => void
           clearInterval(progressTimer);
           if (!calledDone.current) {
             calledDone.current = true;
-            setTimeout(onDone, 300);
+            setTimeout(() => onDoneRef.current(), 300);
           }
           return 100;
         }

--- a/frontend/src/components/views/IdleView.tsx
+++ b/frontend/src/components/views/IdleView.tsx
@@ -26,6 +26,16 @@ const ICONS: Record<ToolId, React.ElementType> = {
 const CAPS_KEYS = ['domain', 'email', 'phone', 'username'] as const;
 type CapsKey = typeof CAPS_KEYS[number];
 
+const TARGETS = [
+  'domain.com',
+  '192.168.1.1',
+  'user@example.com',
+  '@username',
+  '+1 555 000 0000',
+];
+
+const statValues = [22, 12, 5, 0];
+
 interface Props {
   onTool: (mode: ToolMode) => void;
   onScan: (target: string, type: ScanType, modules: string[]) => void;
@@ -48,9 +58,6 @@ export function IdleView({ onTool, onScan, isStarting = false }: Props) {
     const type = detectScanType(target);
     onScan(target, type, MODULE_MAP[type]);
   };
-
-  const statValues = [22, 12, 5, 0];
-  const TARGETS = ['domain.com', '192.168.1.1', 'user@example.com', '@username', '+1 555 000 0000'];
 
   useEffect(() => {
     const target = TARGETS[targetIdx];
@@ -143,19 +150,19 @@ export function IdleView({ onTool, onScan, isStarting = false }: Props) {
 
       <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-3 w-full max-w-2xl mb-8">
         {CAPS_KEYS.map(capKey => (
-            <div key={capKey} className="card p-3 hover:border-border-3 transition-colors">
-              <div className="flex items-center gap-1.5 mb-2">
-                {capKey === 'domain' && <Globe size={10} className="text-blue shrink-0 opacity-80" />}
-                {capKey === 'email' && <User size={10} className="text-blue shrink-0 opacity-80" />}
-                {capKey === 'phone' && <Phone size={10} className="text-blue shrink-0 opacity-80" />}
-                {capKey === 'username' && <Shield size={10} className="text-blue shrink-0 opacity-80" />}
-                <div className="text-[10px] font-bold text-blue uppercase tracking-wider">{t(`idle.caps.${capKey}.title`)}</div>
-              </div>
-              <div className="text-[11px] text-text-3 leading-relaxed">{t(`idle.caps.${capKey}.item1`)}</div>
-              <div className="text-[11px] text-text-3 leading-relaxed">{t(`idle.caps.${capKey}.item2`)}</div>
-              {capKey !== 'phone' && <div className="text-[11px] text-text-3 leading-relaxed">{t(`idle.caps.${capKey}.item3`)}</div>}
+          <div key={capKey} className="card p-3 hover:border-border-3 transition-colors">
+            <div className="flex items-center gap-1.5 mb-2">
+              {capKey === 'domain' && <Globe size={10} className="text-blue shrink-0 opacity-80" />}
+              {capKey === 'email' && <User size={10} className="text-blue shrink-0 opacity-80" />}
+              {capKey === 'phone' && <Phone size={10} className="text-blue shrink-0 opacity-80" />}
+              {capKey === 'username' && <Shield size={10} className="text-blue shrink-0 opacity-80" />}
+              <div className="text-[10px] font-bold text-blue uppercase tracking-wider">{t(`idle.caps.${capKey}.title`)}</div>
             </div>
-          ))}
+            <div className="text-[11px] text-text-3 leading-relaxed">{t(`idle.caps.${capKey}.item1`)}</div>
+            <div className="text-[11px] text-text-3 leading-relaxed">{t(`idle.caps.${capKey}.item2`)}</div>
+            {capKey !== 'phone' && <div className="text-[11px] text-text-3 leading-relaxed">{t(`idle.caps.${capKey}.item3`)}</div>}
+          </div>
+        ))}
       </div>
 
       <div className="w-full max-w-2xl">

--- a/frontend/src/lib/useTheme.ts
+++ b/frontend/src/lib/useTheme.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 export function useTheme() {
   const [theme, setTheme] = useState<'light' | 'dark'>('dark');
@@ -13,12 +13,12 @@ export function useTheme() {
     setMounted(true);
   }, []);
 
-  const toggleTheme = () => {
+  const toggleTheme = useCallback(() => {
     const newTheme = theme === 'dark' ? 'light' : 'dark';
     setTheme(newTheme);
     localStorage.setItem('theme', newTheme);
     document.documentElement.setAttribute('data-theme', newTheme);
-  };
+  }, [theme]);
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -31,7 +31,7 @@ export function useTheme() {
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, [theme]);
+  }, [theme, toggleTheme]);
 
   return { theme, toggleTheme, mounted };
 }


### PR DESCRIPTION
Fixes issue #322 by clearing all four react-hooks/exhaustive-deps warnings.

- Stabilized TARGETS and statValues in IdleView.
- Memoized toggleTheme with useCallback.
- Used a ref for onDone to prevent the loading animation from restarting.
- npm run lint and npx tsc --noEmit pass.
- No intentional behavior changes.