### PR TITLE
test: pin detect_type cases incl player1234567 as username (#204)

### DIFF
--- a/tests/test_cli_target_normalization.py
+++ b/tests/test_cli_target_normalization.py
@@ -18,6 +18,21 @@ def test_normalize_target(raw, expected):
     assert cli.normalize_target(raw) == expected
 
 
+@pytest.mark.parametrize(
+    ("target", "expected"),
+    [
+        ("user@example.com", "email"),
+        ("+1 555 000 0000", "phone"),
+        ("8.8.8.8", "ip"),
+        ("example.com", "domain"),
+        ("player1234567", "username"),
+        ("t.me/someuser", "telegram"),
+    ],
+)
+def test_detect_type(target, expected):
+    assert cli.detect_type(target) == expected
+
+
 def test_detect_type_after_normalization():
     normalized = cli.normalize_target(" https://Example.COM/ ")
 


### PR DESCRIPTION
## Summary

Add test coverage for the current `cli.detect_type` behavior for issue #204.

**No production code was changed.** The `detect_type` implementation and existing `@` handling were left untouched to avoid conflicting with the separate `@durov` fix.

## Changes

Added a parametrized `test_detect_type` in `tests/test_cli_target_normalization.py` covering:

* `user@example.com` → `email`
* `+1 555 000 0000` → `phone`
* `8.8.8.8` → `ip`
* `example.com` → `domain`
* `player1234567` → `username`
* `t.me/someuser` → `telegram`

The `player1234567` case explicitly covers the regression where a username containing several digits must not be incorrectly classified as a phone number.

## Type of change

* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [x] Test-only change (no production code modification)

## Testing

* `python -m pytest tests/test_cli_target_normalization.py -v`
* 14/14 tests passed

The full `pytest tests/` run currently has 50 pre-existing failures related to missing environment dependencies (`slowapi`, `aiohttp`). These failures are unrelated to this change.

## Screenshots

N/A
