### PR TITLE
feat(extension): show target server host in scan view

### DIFF
--- a/extension/popup.css
+++ b/extension/popup.css
@@ -30,6 +30,7 @@ hr { border: none; border-top: 1px solid #21262d; margin: 18px 0; }
 .status { font-size: 11px; color: #8b949e; }
 .status.ok { color: #3fb950; }
 .status.err { color: #f85149; }
+.scan-server-info { font-size: 11px; color: #6e7681; margin-top: -8px; margin-bottom: 12px; text-align: center; }
 
 .bar-wrap { height: 4px; background: #161b22; border-radius: 4px; overflow: hidden; margin-bottom: 12px; }
 .bar { height: 100%; width: 0; background: linear-gradient(90deg,#4f8ef7,#7c5cfc); transition: width .3s ease; }

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -36,6 +36,7 @@
         <span class="scan-target" id="scanTarget"></span>
         <span class="status" id="status"></span>
       </div>
+      <div id="scanServerInfo" class="scan-server-info" hidden></div>
       <div class="bar-wrap" id="barWrap"><div class="bar" id="bar"></div></div>
       <div class="log" id="log"></div>
       <div id="results"></div>

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -155,12 +155,27 @@ function fail(msg) {
 }
 
 let seen;
-function resetScanUi(target) {
+function resetScanUi(target, server) {
   seen = new Set();
   clear(logEl); clear($("results")); $("error").hidden = true;
   barWrap.classList.remove("done"); bar.style.width = "0";
   $("scanTarget").textContent = target;
   $("scanTarget").title = target;
+
+  const serverInfoEl = $("scanServerInfo");
+  if (server) {
+    try {
+      // Use new URL(server).host to get a compact representation like 'getprism.su' or 'localhost:8080'
+      serverInfoEl.textContent = `via ${new URL(server).host}`;
+      serverInfoEl.hidden = false;
+    } catch (e) {
+      // Fallback for invalid URLs, though baseUrl() should prevent this.
+      serverInfoEl.textContent = `via ${server}`;
+      serverInfoEl.hidden = false;
+    }
+  } else {
+    serverInfoEl.hidden = true;
+  }
 }
 function pushLog(msg) {
   const key = `${msg.type}:${msg.module}`;
@@ -179,7 +194,7 @@ function pushLog(msg) {
 }
 
 async function start(target, server, apiKey) {
-  showScan(); resetScanUi(target); setStatus(t("scanning", "Scanning…"));
+  showScan(); resetScanUi(target, server); setStatus(t("scanning", "Scanning…"));
   const headers = { "Content-Type": "application/json" };
   if (apiKey) headers["X-API-Key"] = apiKey;
   let scanId;
@@ -199,7 +214,7 @@ async function start(target, server, apiKey) {
 }
 
 function resume(active) {
-  resetScanUi(active.target); setStatus(t("scanning", "Scanning…"));
+  resetScanUi(active.target, active.server); setStatus(t("scanning", "Scanning…"));
   poll(active);
 }
 


### PR DESCRIPTION
The popup only showed the scan target, so it was unclear which PRISM instance (local or demo) the results came from once a scan started.

Add a small muted line under the scan header showing the server host (e.g. getprism.su or localhost:8080). Populated in resetScanUi() from the server URL already passed to start() and resume(), using new URL(server).host so it stays compact. Built with textContent, no innerHTML.

Closes #271

## Summary
<!-- Describe your changes briefly -->

## Changes
<!-- List specific changes -->
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
