### PR TITLE
fix(cli): detect_type(@durov) should return username, not email (fixes #345)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -33,6 +33,9 @@ def normalize_target(target: str) -> str:
 
 
 def detect_type(target: str) -> str:
+    # A leading @ with nothing in front means a Telegram-style username, not email
+    if target.startswith("@") and "@" not in target[1:]:
+        return "username"
     if "@" in target:
         return "email"
     stripped = target.replace("+", "").replace("-", "").replace(" ", "")

--- a/tests/test_cli_target_normalization.py
+++ b/tests/test_cli_target_normalization.py
@@ -27,6 +27,8 @@ def test_normalize_target(raw, expected):
         ("example.com", "domain"),
         ("player1234567", "username"),
         ("t.me/someuser", "telegram"),
+        ("@durov", "username"),
+        ("@MixedCaseUser", "username"),
     ],
 )
 def test_detect_type(target, expected):


### PR DESCRIPTION
## Summary

- `detect_type("@durov")` was returning `"email"` instead of `"username"`.
- Any string containing `@` was classified as email, so Telegram-style handles
  with a leading `@` got email modules instead of username ones.
- The fix: a leading `@` with no other `@` in the rest of the string is a
  handle, not an address.

Fixes #345.

## Changes

- `cli.py` — added a leading-`@` guard before the generic `("@" in target)`
  email branch.
- `tests/test_cli_target_normalization.py` — adds `@durov` and
  `@MixedCaseUser` as username cases, alongside the existing `player1234567`
  guard that prevents digit-counting regression.

## Verification

- `pytest tests/test_cli_target_normalization.py -q` → 16 passed.
- `detect_type("@durov") == "username"` ✓
- `detect_type("a@b.com") == "email"` ✓
- `detect_type("@MixedCaseUser") == "username"` ✓
- `detect_type("player1234567") == "username"` ✓ (no regression)
