### PR TITLE
fix(normalizer): strip mailto: prefix and query params from email targets (#353)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20,6 +20,11 @@ __version__ = PRISM_VERSION
 
 def normalize_target(target: str) -> str:
     normalized = target.strip()
+    if normalized.lower().startswith("mailto:"):
+        normalized = normalized[7:].strip()
+        q_pos = normalized.find("?")
+        if q_pos != -1:
+            normalized = normalized[:q_pos].strip()
     scheme_sep = normalized.find("://")
     if scheme_sep != -1 and normalized[:scheme_sep].lower() in {"http", "https"}:
         normalized = normalized[scheme_sep + 3:]

--- a/frontend/scripts/test-scan-target.mjs
+++ b/frontend/scripts/test-scan-target.mjs
@@ -50,13 +50,23 @@ try {
 
   assert.equal(
     normalizeScanTarget('mailto:user@example.com'),
-    'mailto:user@example.com',
-    'mailto: prefix should be preserved'
+    'user@example.com',
+    'mailto: prefix should be stripped'
   );
   assert.equal(
     normalizeScanTarget('MAILTO:USER@EXAMPLE.COM'),
-    'mailto:user@example.com',
-    'mailto: prefix should be lowercased and email lowercased'
+    'user@example.com',
+    'MAILTO: prefix should be stripped and email lowercased'
+  );
+  assert.equal(
+    normalizeScanTarget('mailto:a@b.com?subject=x'),
+    'a@b.com',
+    'mailto: prefix and query string should be stripped'
+  );
+  assert.equal(
+    normalizeScanTarget('MAILTO:User@Example.COM?subject=hi&body=hello'),
+    'user@example.com',
+    'case-insensitive mailto: and query string should be stripped and lowercased'
   );
 
   assert.equal(
@@ -149,6 +159,11 @@ try {
     detectScanType('MAILTO:USER@EXAMPLE.COM'),
     'email',
     'mailto: uppercase should detect as email'
+  );
+  assert.equal(
+    detectScanType('mailto:a@b.com?subject=x'),
+    'email',
+    'mailto: with query should detect as email'
   );
 
   assert.equal(

--- a/frontend/src/lib/scan-target.ts
+++ b/frontend/src/lib/scan-target.ts
@@ -3,6 +3,14 @@ import type { ScanType } from './types';
 export function normalizeScanTarget(value: string): string {
   let normalized = value.trim();
 
+  if (normalized.toLowerCase().startsWith('mailto:')) {
+    normalized = normalized.slice(7).trim();
+    const qIndex = normalized.indexOf('?');
+    if (qIndex !== -1) {
+      normalized = normalized.slice(0, qIndex).trim();
+    }
+  }
+
   const schemeSep = normalized.indexOf('://');
   if (schemeSep !== -1) {
     const scheme = normalized.slice(0, schemeSep).toLowerCase();

--- a/tests/test_cli_target_normalization.py
+++ b/tests/test_cli_target_normalization.py
@@ -12,6 +12,10 @@ import cli
         (" User@Example.COM ", "user@example.com"),
         ("+1 555 000 0000", "+1 555 000 0000"),
         ("@MixedCaseUser", "@MixedCaseUser"),
+        ("mailto:user@example.com", "user@example.com"),
+        ("MAILTO:USER@EXAMPLE.COM", "user@example.com"),
+        ("mailto:a@b.com?subject=x", "a@b.com"),
+        ("MAILTO:User@Example.COM?subject=hi&body=hello", "user@example.com"),
     ],
 )
 def test_normalize_target(raw, expected):
@@ -22,6 +26,8 @@ def test_normalize_target(raw, expected):
     ("target", "expected"),
     [
         ("user@example.com", "email"),
+        ("mailto:user@example.com", "email"),
+        ("mailto:a@b.com?subject=x", "email"),
         ("+1 555 000 0000", "phone"),
         ("8.8.8.8", "ip"),
         ("example.com", "domain"),


### PR DESCRIPTION
## Summary

Closes #353.

When pasting an email target such as `mailto:someone@example.com` or `mailto:a@b.com?subject=hi`, the `mailto:` prefix survived into the scan target string and was passed down to underlying email reconnaissance modules.

This change keeps both normalizers (`cli.py` on the backend and `frontend/src/lib/scan-target.ts` on the frontend) in sync:
- Case-insensitively strips leading `mailto:` prefixes (`mailto:`, `MAILTO:`).
- Drops query parameter strings following `?` (e.g., `?subject=x`).
- Preserves downstream email casing normalization (lowercased) and scan type detection (`email`).

## Changes Made

1. **`cli.py` (`normalize_target`)**:
   - Strips leading case-insensitive `mailto:` prefix.
   - Drops anything after `?` to cleanly extract the email address.

2. **`frontend/src/lib/scan-target.ts` (`normalizeScanTarget`)**:
   - Mirrors the same `mailto:` and query parameter stripping logic before scheme and domain normalization.

3. **`frontend/scripts/test-scan-target.mjs`**:
   - Updates `normalizeScanTarget` test assertions to verify that `mailto:` is stripped rather than retained.
   - Adds test cases for `mailto:a@b.com?subject=x` and case-insensitive query parameter handling.
   - Verifies `detectScanType` correctly recognizes `mailto:a@b.com?subject=x` as `'email'`.

4. **`tests/test_cli_target_normalization.py`**:
   - Adds test cases in `test_normalize_target` verifying `mailto:user@example.com`, `MAILTO:USER@EXAMPLE.COM`, `mailto:a@b.com?subject=x`, and mixed-case query strings all resolve to clean lowercased email addresses.
   - Adds `test_detect_type` assertions for `mailto:` inputs.

## Verification

- `node scripts/test-scan-target.mjs` in `frontend/`: **Passed** (`scan target normalization tests passed`).
- All frontend test suites (`test:urls`, `test:i18n`, `test:i18n-lookup`, `test:scan-target`, `test:encoder`): **Passed**.
- TypeScript check (`tsc --noEmit src/lib/scan-target.ts`): **Passed with 0 errors**.
- `pytest tests/test_cli_target_normalization.py`: **20 passed**.
- Full pytest test suite (`pytest tests/ -q`): **All 393 tests passed**.
- Flake8 critical rules check (`flake8 --count --select=E9,F63,F7,F82`): **0 errors**.
- DCO: Commit signed off per Developer Certificate of Origin (`git commit -s`).
