### PR TITLE
fix(cli): detect_type("@handle") returns username, not email

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -33,7 +33,7 @@ def normalize_target(target: str) -> str:
 
 
 def detect_type(target: str) -> str:
-    if "@" in target:
+    if "@" in target and not target.startswith("@"):
         return "email"
     stripped = target.replace("+", "").replace("-", "").replace(" ", "")
     if stripped.isdigit():

--- a/tests/test_cli_target_normalization.py
+++ b/tests/test_cli_target_normalization.py
@@ -27,6 +27,8 @@ def test_normalize_target(raw, expected):
         ("example.com", "domain"),
         ("player1234567", "username"),
         ("t.me/someuser", "telegram"),
+        ("@durov", "username"),
+        ("a@b.com", "email"),
     ],
 )
 def test_detect_type(target, expected):


### PR DESCRIPTION
A leading @ means a username, not an email — an email has content on both sides of the @. Any @ anywhere was being treated as email, so "@durov" got the email modules instead of the username ones.

Guard the email branch with `not target.startswith("@")`. The player1234567 phone case pinned in tests stays passing, and both "@durov" -> username and "a@b.com" -> email are now covered.

Closes #345

## Summary
<!-- Describe your changes briefly -->

## Changes
<!-- List specific changes -->
- 

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] I have tested these changes locally
- [ ] I have added/updated tests as needed

## Screenshots
<!-- If applicable, add screenshots -->
