### PR TITLE
fix: leading @ is username; strip mailto: from targets

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20,6 +20,13 @@ __version__ = PRISM_VERSION
 
 def normalize_target(target: str) -> str:
     normalized = target.strip()
+    # mailto:someone@example.com?subject=hi -> someone@example.com
+    if normalized.lower().startswith("mailto:"):
+        normalized = normalized[7:]
+        q = normalized.find("?")
+        if q != -1:
+            normalized = normalized[:q]
+        normalized = normalized.strip()
     scheme_sep = normalized.find("://")
     if scheme_sep != -1 and normalized[:scheme_sep].lower() in {"http", "https"}:
         normalized = normalized[scheme_sep + 3:]
@@ -33,6 +40,12 @@ def normalize_target(target: str) -> str:
 
 
 def detect_type(target: str) -> str:
+    # Leading @ is a username/handle, not an email (e.g. @durov).
+    if target.startswith("@"):
+        t = target.lstrip("@")
+        if t.startswith("t.me/") or t.startswith("telegram.me/"):
+            return "telegram"
+        return "username"
     if "@" in target:
         return "email"
     stripped = target.replace("+", "").replace("-", "").replace(" ", "")

--- a/frontend/src/lib/scan-target.ts
+++ b/frontend/src/lib/scan-target.ts
@@ -3,6 +3,14 @@ import type { ScanType } from './types';
 export function normalizeScanTarget(value: string): string {
   let normalized = value.trim();
 
+  // mailto:a@b.com?subject=hi -> a@b.com
+  if (normalized.toLowerCase().startsWith('mailto:')) {
+    normalized = normalized.slice(7);
+    const q = normalized.indexOf('?');
+    if (q !== -1) normalized = normalized.slice(0, q);
+    normalized = normalized.trim();
+  }
+
   const schemeSep = normalized.indexOf('://');
   if (schemeSep !== -1) {
     const scheme = normalized.slice(0, schemeSep).toLowerCase();


### PR DESCRIPTION
## Summary
- \`detect_type(\"@durov\")\` returned \`email\` because any \`@\` was treated as email.
- \`mailto:a@b.com?subject=x\` kept the scheme prefix through both CLI and frontend normalizers.

## Changes
- Leading \`@\` → \`username\` (or telegram for \`t.me\` / \`telegram.me\`)
- Strip leading \`mailto:\` (any case) and drop \`?...\` query in \`normalize_target\` and \`normalizeScanTarget\`

Closes #345  
Closes #353